### PR TITLE
Restore $lib exports for state and favicon

### DIFF
--- a/apps/web/src/lib/index.ts
+++ b/apps/web/src/lib/index.ts
@@ -1,7 +1,5 @@
 // place files you want to import through the `$lib` alias in this folder.
 
-// Only needed for TS to understand SVG imports
-declare module "*.svg" {
-  const content: string;
-  export default content;
-}
+export * from "./stores/state";
+export * from "./stores/storage";
+export { default as favicon } from "./assets/favicon.svg";

--- a/apps/web/src/lib/parsing/parseTask.test.ts
+++ b/apps/web/src/lib/parsing/parseTask.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { parseTaskLine, formatTask, parseMarkdown, Task } from "./parseTask";
+import { parseTaskLine, formatTask, parseMarkdown } from "./parseTask";
 
 describe("parseTaskLine", () => {
   it("parses an unchecked task without tags", () => {

--- a/apps/web/src/lib/stores/storage/constants.ts
+++ b/apps/web/src/lib/stores/storage/constants.ts
@@ -1,0 +1,17 @@
+/**
+ * Centralised constants for storage implementation.
+ *
+ * Keeping these here lets other tasks tweak retention windows or storage keys
+ * without hunting through the engine implementation.
+ */
+export const STORAGE_KEY_ROOT = "kelpie.storage";
+
+export const STORAGE_SCHEMA_VERSION = 1;
+
+export const DEFAULT_HISTORY_RETENTION_DAYS = 7;
+export const DEFAULT_HISTORY_ENTRY_CAP = 200;
+export const DEFAULT_AUDIT_ENTRY_CAP = 200;
+export const DEFAULT_SOFT_DELETE_RETENTION_DAYS = 7;
+
+export const DEFAULT_DEBOUNCE_WRITE_MS = 2000;
+export const DEFAULT_DEBOUNCE_BROADCAST_MS = 1000;

--- a/apps/web/src/lib/stores/storage/defaults.ts
+++ b/apps/web/src/lib/stores/storage/defaults.ts
@@ -1,0 +1,65 @@
+import {
+    DEFAULT_AUDIT_ENTRY_CAP,
+    DEFAULT_DEBOUNCE_BROADCAST_MS,
+    DEFAULT_DEBOUNCE_WRITE_MS,
+    DEFAULT_HISTORY_ENTRY_CAP,
+    DEFAULT_HISTORY_RETENTION_DAYS,
+    DEFAULT_SOFT_DELETE_RETENTION_DAYS,
+    STORAGE_SCHEMA_VERSION
+} from "./constants";
+import type { RuntimeConfiguration, StorageSnapshot, UiSettings } from "./types";
+
+function isoNow(): string {
+    return new Date().toISOString();
+}
+
+export function createDefaultConfiguration(): RuntimeConfiguration {
+    return {
+        debounce: {
+            writeMs: DEFAULT_DEBOUNCE_WRITE_MS,
+            broadcastMs: DEFAULT_DEBOUNCE_BROADCAST_MS
+        },
+        historyRetentionDays: DEFAULT_HISTORY_RETENTION_DAYS,
+        historyEntryCap: DEFAULT_HISTORY_ENTRY_CAP,
+        auditEntryCap: DEFAULT_AUDIT_ENTRY_CAP,
+        softDeleteRetentionDays: DEFAULT_SOFT_DELETE_RETENTION_DAYS
+    };
+}
+
+export function createDefaultSettings(): UiSettings {
+    const now = isoNow();
+    return {
+        lastActiveDocumentId: null,
+        panes: {},
+        filters: {},
+        createdAt: now,
+        updatedAt: now
+    };
+}
+
+function createInstallationId(): string {
+    if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+        return crypto.randomUUID();
+    }
+    return Math.random().toString(36).slice(2);
+}
+
+export function createInitialSnapshot(): StorageSnapshot {
+    const now = isoNow();
+    const installationId = createInstallationId();
+
+    return {
+        meta: {
+            version: STORAGE_SCHEMA_VERSION,
+            installationId,
+            createdAt: now,
+            lastOpenedAt: now
+        },
+        config: createDefaultConfiguration(),
+        settings: createDefaultSettings(),
+        index: [],
+        documents: {},
+        history: [],
+        audit: []
+    };
+}

--- a/apps/web/src/lib/stores/storage/driver.ts
+++ b/apps/web/src/lib/stores/storage/driver.ts
@@ -1,0 +1,57 @@
+import type { StorageSnapshot } from "./types";
+
+/**
+ * Abstraction over the host storage API (localStorage for MVP).
+ *
+ * Having a thin driver interface makes it straightforward to swap in
+ * alternative persistence layers in future tasks or tests.
+ */
+export interface StorageDriver {
+    load(): StorageSnapshot | null;
+    save(snapshot: StorageSnapshot): void;
+    clear(): void;
+    /**
+     * Subscribe to external changes (e.g. storage events from other tabs).
+     * Returns an unsubscribe function.
+     */
+    subscribe(callback: () => void): () => void;
+}
+
+export function createLocalStorageDriver(key: string): StorageDriver {
+    return {
+        load() {
+            if (typeof localStorage === "undefined") return null;
+            const raw = localStorage.getItem(key);
+            if (!raw) return null;
+
+            try {
+                return JSON.parse(raw) as StorageSnapshot;
+            } catch (error) {
+                console.warn("Kelpie storage: failed to parse snapshot", error);
+                return null;
+            }
+        },
+        save(snapshot) {
+            if (typeof localStorage === "undefined") return;
+            localStorage.setItem(key, JSON.stringify(snapshot));
+        },
+        clear() {
+            if (typeof localStorage === "undefined") return;
+            localStorage.removeItem(key);
+        },
+        subscribe(callback) {
+            if (typeof window === "undefined") {
+                return () => {};
+            }
+
+            const handler = (event: StorageEvent) => {
+                if (event.key === key) {
+                    callback();
+                }
+            };
+
+            window.addEventListener("storage", handler);
+            return () => window.removeEventListener("storage", handler);
+        }
+    };
+}

--- a/apps/web/src/lib/stores/storage/engine.ts
+++ b/apps/web/src/lib/stores/storage/engine.ts
@@ -1,0 +1,82 @@
+import { readable, writable, type Readable } from "svelte/store";
+import { STORAGE_KEY_ROOT } from "./constants";
+import { createDefaultConfiguration, createInitialSnapshot } from "./defaults";
+import { createLocalStorageDriver, type StorageDriver } from "./driver";
+import type {
+    RuntimeConfiguration,
+    StorageBroadcast,
+    StorageSnapshot,
+    UiSettings
+} from "./types";
+
+export type StorageEngine = {
+    snapshot: Readable<StorageSnapshot>;
+    config: Readable<RuntimeConfiguration>;
+    settings: Readable<UiSettings>;
+    /** Forces a reload from the underlying driver. */
+    refresh(): void;
+    /** Resets storage to defaults, clearing existing data. */
+    reset(): void;
+    /** Update functions are intentionally left unimplemented for follow-up tasks. */
+};
+
+export type StorageEngineOptions = {
+    driver?: StorageDriver;
+};
+
+/**
+ * Creates a storage engine with reactive Svelte stores.
+ *
+ * The current implementation only hydrates defaults and exposes read-only
+ * stores. Write/update flows will be implemented in future tasks.
+ */
+export function createStorageEngine(options: StorageEngineOptions = {}): StorageEngine {
+    const driver = options.driver ?? createLocalStorageDriver(STORAGE_KEY_ROOT);
+    const initial = driver.load() ?? createInitialSnapshot();
+
+    const snapshotStore = writable<StorageSnapshot>(initial);
+    const configStore = readable(initial.config);
+    const settingsStore = writable<UiSettings>(initial.settings);
+
+    function refresh() {
+        const next = driver.load();
+        if (next) {
+            snapshotStore.set(next);
+            settingsStore.set(next.settings);
+        }
+    }
+
+    function reset() {
+        const freshSnapshot: StorageSnapshot = {
+            ...createInitialSnapshot(),
+            config: createDefaultConfiguration()
+        };
+        driver.save(freshSnapshot);
+        snapshotStore.set(freshSnapshot);
+        settingsStore.set(freshSnapshot.settings);
+    }
+
+    driver.subscribe(() => {
+        refresh();
+    });
+
+    return {
+        snapshot: snapshotStore,
+        config: configStore,
+        settings: settingsStore,
+        refresh,
+        reset
+    };
+}
+
+/**
+ * Convenience helper for wiring storage broadcasts. Currently this is a stub
+ * that simply wraps setTimeout to keep type signatures ready for future work.
+ */
+export function scheduleBroadcast(
+    _broadcast: StorageBroadcast,
+    _options: { driver?: StorageDriver } = {}
+): void {
+    // Placeholder implementation: future work will push messages via BroadcastChannel or similar.
+    void _broadcast;
+}

--- a/apps/web/src/lib/stores/storage/index.ts
+++ b/apps/web/src/lib/stores/storage/index.ts
@@ -1,0 +1,5 @@
+export * from "./constants";
+export * from "./defaults";
+export * from "./driver";
+export * from "./engine";
+export * from "./types";

--- a/apps/web/src/lib/stores/storage/types.ts
+++ b/apps/web/src/lib/stores/storage/types.ts
@@ -1,0 +1,110 @@
+/**
+ * Shared types describing the persisted storage schema.
+ *
+ * The goal is to keep all schema-related definitions colocated so that
+ * follow-up tasks can focus on feature-specific logic (history, audit, gc, etc.)
+ * without repeating structural assumptions.
+ */
+export type IsoDateTimeString = string; // ISO-8601 timestamps only.
+
+export type InstallationMeta = {
+    version: number;
+    installationId: string;
+    createdAt: IsoDateTimeString;
+    lastOpenedAt: IsoDateTimeString;
+    migratedFrom?: string;
+};
+
+export type RuntimeConfiguration = {
+    debounce: {
+        writeMs: number;
+        broadcastMs: number;
+    };
+    historyRetentionDays: number;
+    historyEntryCap: number;
+    auditEntryCap: number;
+    softDeleteRetentionDays: number;
+};
+
+export type UiSettings = {
+    lastActiveDocumentId: string | null;
+    panes: Record<string, boolean>;
+    filters: Record<string, unknown>;
+    createdAt: IsoDateTimeString;
+    updatedAt: IsoDateTimeString;
+};
+
+export type DocumentIndexEntry = {
+    id: string;
+    title: string;
+    createdAt: IsoDateTimeString;
+    updatedAt: IsoDateTimeString;
+    deletedAt: IsoDateTimeString | null;
+    purgeAfter: IsoDateTimeString | null;
+};
+
+export type DocumentIndex = DocumentIndexEntry[];
+
+export type DocumentSnapshot = {
+    id: string;
+    title: string;
+    content: string;
+    createdAt: IsoDateTimeString;
+    updatedAt: IsoDateTimeString;
+    lastEditedBy?: string;
+};
+
+export type HistoryScope = "document" | "settings";
+
+export type HistoryEntry = {
+    id: string;
+    scope: HistoryScope;
+    refId: string; // document id for doc history, "settings" otherwise
+    snapshot: unknown; // will be narrowed by feature-specific modules
+    createdAt: IsoDateTimeString;
+    author?: string;
+};
+
+export type AuditEventType =
+    | "document.created"
+    | "document.updated"
+    | "document.deleted"
+    | "document.restored"
+    | "history.pruned"
+    | "settings.updated"
+    | "migration.completed"
+    | "storage.reset"
+    | "storage.corruption";
+
+export type AuditEntry = {
+    id: string;
+    type: AuditEventType;
+    createdAt: IsoDateTimeString;
+    author?: string;
+    metadata?: Record<string, unknown>;
+};
+
+export type StorageSnapshot = {
+    meta: InstallationMeta;
+    config: RuntimeConfiguration;
+    settings: UiSettings;
+    index: DocumentIndex;
+    documents: Record<string, DocumentSnapshot>;
+    history: HistoryEntry[];
+    audit: AuditEntry[];
+};
+
+export type StorageMutationResult = {
+    snapshot: StorageSnapshot;
+    writes: number;
+    sizeInBytes: number;
+};
+
+/**
+ * Event payload describing a change broadcast across tabs.
+ */
+export type StorageBroadcast = {
+    scope: "snapshot" | "documents" | "settings" | "config" | "history" | "audit";
+    updatedAt: IsoDateTimeString;
+    origin: "local" | "external";
+};

--- a/apps/web/src/lib/types.d.ts
+++ b/apps/web/src/lib/types.d.ts
@@ -1,0 +1,5 @@
+// Ambient module declaration for bundling SVGs via the $lib alias.
+declare module "*.svg" {
+    const content: string;
+    export default content;
+}

--- a/specs/storage.spec.md
+++ b/specs/storage.spec.md
@@ -201,10 +201,14 @@ This section is for the AI or developers to update after implementation runs.
   - `/apps/web/src/lib/stores/`
 
 - **What has been implemented**:
-  - (AI fills in)
+  - Storage schema types and defaults scaffolding (`apps/web/src/lib/stores/storage/*`)
+  - Local storage driver wrapper with subscription hook
+  - Initial storage engine exposing read-only Svelte stores and reset/refresh utilities
 
 - **What remains to be implemented**:
-  - (AI fills in)
+  - Document/index/settings mutation APIs and undo/redo history management
+  - Audit logging, garbage collection, and multi-tab broadcast channel
+  - Migration, corruption handling, and developer inspector utilities
 
 - **Test files and coverage**:
   - Unit tests for history eviction: `/apps/web/src/lib/stores/storage-history.test.ts`


### PR DESCRIPTION
## Summary
- restore the $lib index exports for state stores alongside the new storage exports
- drop the unused Task import from the parseTask tests to satisfy verbatim module syntax

## Testing
- pnpm -C apps/web check

------
https://chatgpt.com/codex/tasks/task_e_68d659c670048329bc0efc20dd8f5012