### PR TITLE
Ensure two-space indentation configuration

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,8 @@
     "source.fixAll": "explicit",
     "source.fixAll.eslint": true
   },
+  "editor.tabSize": 2,
+  "editor.detectIndentation": false,
   "eslint.validate": ["typescript", "svelte"],
   "files.eol": "\n",
   "svelte.enable-ts-plugin": true

--- a/apps/web/.prettierrc
+++ b/apps/web/.prettierrc
@@ -1,17 +1,18 @@
 {
-	"useTabs": false,
-	"singleQuote": false,
-    "semi": true,
-	"trailingComma": "none",
-	"printWidth": 120,
-	"plugins": ["prettier-plugin-svelte", "prettier-plugin-tailwindcss"],
-	"overrides": [
-		{
-			"files": "*.svelte",
-			"options": {
-				"parser": "svelte"
-			}
-		}
-	],
-	"tailwindStylesheet": "./src/app.css"
+  "useTabs": false,
+  "tabWidth": 2,
+  "singleQuote": false,
+  "semi": true,
+  "trailingComma": "none",
+  "printWidth": 120,
+  "plugins": ["prettier-plugin-svelte", "prettier-plugin-tailwindcss"],
+  "overrides": [
+    {
+      "files": "*.svelte",
+      "options": {
+        "parser": "svelte"
+      }
+    }
+  ],
+  "tailwindStylesheet": "./src/app.css"
 }


### PR DESCRIPTION
## Summary
- configure the workspace settings to always use a two-space tab width
- align the web app Prettier configuration with two-space indentation and add an explicit tab width

## Testing
- not run (configuration change only)

------
https://chatgpt.com/codex/tasks/task_e_68d664d2a1748329abc105ebe42e7a9f