### PR TITLE
Fix editor draft resetting while typing

### DIFF
--- a/apps/web/src/lib/panels/editor/CodeEditorPanel.svelte
+++ b/apps/web/src/lib/panels/editor/CodeEditorPanel.svelte
@@ -12,8 +12,9 @@
     export let placeholder = "- [ ] Example task @due(2025-10-01) #tag";
 
     let draft = value;
+    let isEditing = false;
 
-    $: if (value !== draft) {
+    $: if (!isEditing && value !== draft) {
         draft = value;
     }
 
@@ -21,6 +22,16 @@
         const target = event.target as HTMLTextAreaElement;
         draft = target.value;
         dispatch("contentChange", { value: draft });
+    }
+
+    function handleFocus() {
+        isEditing = true;
+        dispatch("editingState", { isEditing: true });
+    }
+
+    function handleBlur() {
+        isEditing = false;
+        dispatch("editingState", { isEditing: false });
     }
 </script>
 
@@ -33,8 +44,8 @@
         bind:value={draft}
         placeholder={placeholder}
         on:input={handleInput}
-        on:focus={() => dispatch("editingState", { isEditing: true })}
-        on:blur={() => dispatch("editingState", { isEditing: false })}
+        on:focus={handleFocus}
+        on:blur={handleBlur}
     ></textarea>
 </section>
 


### PR DESCRIPTION
## Summary
- keep the editor's draft content stable while typing by pausing prop sync during focus
- reuse dedicated handlers to toggle the editing state events when the textarea gains or loses focus

## Testing
- npm run lint *(fails: repository has existing formatting issues flagged by Prettier)*

------
https://chatgpt.com/codex/tasks/task_e_68d6645558e88329a8c4affff6245a79