### PR TITLE
Add storage engine unit coverage and reload persistence E2E

### DIFF
--- a/apps/web/e2e/demo.test.ts
+++ b/apps/web/e2e/demo.test.ts
@@ -1,6 +1,31 @@
 import { expect, test } from '@playwright/test';
 
-test('home page has expected h1', async ({ page }) => {
-	await page.goto('/');
-	await expect(page.locator('h1')).toBeVisible();
+test.describe('task persistence', () => {
+        test.beforeEach(async ({ page }) => {
+                await page.goto('/');
+                await page.evaluate(() => localStorage.clear());
+                await page.reload();
+        });
+
+        test('toggled tasks remain checked after reloading the app', async ({ page }) => {
+                const tasks = page.locator('.task-item');
+                await expect(tasks).toHaveCount(2);
+
+                const firstTask = tasks.first();
+                await expect(firstTask).toContainText('Buy milk');
+
+                const firstCheckbox = firstTask.getByRole('checkbox');
+                await firstCheckbox.check();
+                await expect(firstCheckbox).toBeChecked();
+                await expect(firstTask).toHaveClass(/done/);
+
+                await page.reload();
+
+                const tasksAfterReload = page.locator('.task-item');
+                await expect(tasksAfterReload).toHaveCount(2);
+
+                const firstAfterReload = tasksAfterReload.first();
+                await expect(firstAfterReload).toHaveClass(/done/);
+                await expect(firstAfterReload.getByRole('checkbox')).toBeChecked();
+        });
 });

--- a/apps/web/src/lib/stores/storage/engine.test.ts
+++ b/apps/web/src/lib/stores/storage/engine.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { get } from "svelte/store";
+import { createStorageEngine } from "./engine";
+import type { StorageDriver } from "./driver";
+import type { StorageSnapshot } from "./types";
+import { createDefaultConfiguration } from "./defaults";
+
+function createSnapshot(overrides: Partial<StorageSnapshot> = {}): StorageSnapshot {
+    const base: StorageSnapshot = {
+        meta: {
+            version: 1,
+            installationId: "test-installation",
+            createdAt: "2024-01-01T00:00:00.000Z",
+            lastOpenedAt: "2024-01-01T00:00:00.000Z"
+        },
+        config: {
+            debounce: { writeMs: 500, broadcastMs: 200 },
+            historyRetentionDays: 7,
+            historyEntryCap: 50,
+            auditEntryCap: 20,
+            softDeleteRetentionDays: 7
+        },
+        settings: {
+            lastActiveDocumentId: null,
+            panes: {},
+            filters: {},
+            createdAt: "2024-01-01T00:00:00.000Z",
+            updatedAt: "2024-01-01T00:00:00.000Z"
+        },
+        index: [],
+        documents: {},
+        history: [],
+        audit: []
+    };
+
+    return { ...base, ...overrides };
+}
+
+describe("createStorageEngine", () => {
+    let driver: StorageDriver;
+    let loadSpy: ReturnType<typeof vi.fn>;
+    let saveSpy: ReturnType<typeof vi.fn>;
+    let clearSpy: ReturnType<typeof vi.fn>;
+    let triggerSubscription: (() => void) | undefined;
+
+    beforeEach(() => {
+        loadSpy = vi.fn();
+        saveSpy = vi.fn();
+        clearSpy = vi.fn();
+        triggerSubscription = undefined;
+
+        driver = {
+            load: loadSpy,
+            save: saveSpy,
+            clear: clearSpy,
+            subscribe: vi.fn((callback: () => void) => {
+                triggerSubscription = callback;
+                return () => {
+                    triggerSubscription = undefined;
+                };
+            })
+        } satisfies StorageDriver;
+    });
+
+    it("hydrates stores with the driver's snapshot and refreshes them on demand", () => {
+        const initialSnapshot = createSnapshot({
+            meta: { ...createSnapshot().meta, installationId: "initial" }
+        });
+        const refreshedSnapshot = createSnapshot({
+            meta: { ...createSnapshot().meta, installationId: "refreshed" }
+        });
+
+        let current = initialSnapshot;
+        loadSpy.mockImplementation(() => current);
+
+        const engine = createStorageEngine({ driver });
+        expect(get(engine.snapshot)).toEqual(initialSnapshot);
+        expect(get(engine.settings)).toEqual(initialSnapshot.settings);
+
+        current = refreshedSnapshot;
+        engine.refresh();
+
+        expect(loadSpy).toHaveBeenCalledTimes(2);
+        expect(get(engine.snapshot)).toEqual(refreshedSnapshot);
+        expect(get(engine.settings)).toEqual(refreshedSnapshot.settings);
+    });
+
+    it("updates stores when the driver notifies of external changes", () => {
+        const firstSnapshot = createSnapshot({
+            meta: { ...createSnapshot().meta, installationId: "first" }
+        });
+        const secondSnapshot = createSnapshot({
+            meta: { ...createSnapshot().meta, installationId: "second" }
+        });
+
+        let current = firstSnapshot;
+        loadSpy.mockImplementation(() => current);
+
+        const engine = createStorageEngine({ driver });
+        expect(triggerSubscription).toBeTypeOf("function");
+
+        current = secondSnapshot;
+        triggerSubscription?.();
+
+        expect(get(engine.snapshot)).toEqual(secondSnapshot);
+        expect(get(engine.settings)).toEqual(secondSnapshot.settings);
+    });
+
+    it("ignores refresh calls when the driver returns null", () => {
+        const baseline = createSnapshot();
+        loadSpy
+            .mockReturnValueOnce(baseline)
+            .mockReturnValueOnce(null);
+
+        const engine = createStorageEngine({ driver });
+        engine.refresh();
+
+        expect(get(engine.snapshot)).toEqual(baseline);
+        expect(get(engine.settings)).toEqual(baseline.settings);
+    });
+
+    it("resets storage to defaults and persists the new snapshot", () => {
+        const populated = createSnapshot({
+            settings: {
+                lastActiveDocumentId: "doc-123",
+                panes: { editor: true },
+                filters: { status: "open" },
+                createdAt: "2024-01-01T00:00:00.000Z",
+                updatedAt: "2024-01-02T00:00:00.000Z"
+            },
+            index: [
+                {
+                    id: "doc-123",
+                    title: "Doc",
+                    createdAt: "2024-01-01T00:00:00.000Z",
+                    updatedAt: "2024-01-02T00:00:00.000Z",
+                    deletedAt: null,
+                    purgeAfter: null
+                }
+            ],
+            documents: {
+                "doc-123": {
+                    id: "doc-123",
+                    title: "Doc",
+                    content: "Hello",
+                    createdAt: "2024-01-01T00:00:00.000Z",
+                    updatedAt: "2024-01-02T00:00:00.000Z"
+                }
+            },
+            history: [
+                {
+                    id: "hist-1",
+                    scope: "document",
+                    refId: "doc-123",
+                    snapshot: {},
+                    createdAt: "2024-01-02T00:00:00.000Z"
+                }
+            ],
+            audit: [
+                {
+                    id: "audit-1",
+                    type: "document.updated",
+                    createdAt: "2024-01-02T00:00:00.000Z"
+                }
+            ]
+        });
+
+        loadSpy.mockReturnValue(populated);
+
+        const engine = createStorageEngine({ driver });
+        engine.reset();
+
+        expect(saveSpy).toHaveBeenCalledTimes(1);
+        const savedSnapshot = saveSpy.mock.calls[0][0] as StorageSnapshot;
+
+        expect(savedSnapshot.config).toEqual(createDefaultConfiguration());
+        expect(savedSnapshot.index).toEqual([]);
+        expect(savedSnapshot.documents).toEqual({});
+        expect(savedSnapshot.history).toEqual([]);
+        expect(savedSnapshot.audit).toEqual([]);
+        expect(savedSnapshot.settings.lastActiveDocumentId).toBeNull();
+        expect(savedSnapshot.settings.panes).toEqual({});
+        expect(savedSnapshot.settings.filters).toEqual({});
+
+        expect(get(engine.snapshot)).toEqual(savedSnapshot);
+        expect(get(engine.settings)).toEqual(savedSnapshot.settings);
+    });
+});


### PR DESCRIPTION
## Summary
- add unit tests for the storage engine to exercise refresh, subscription updates, null loads, and reset defaults
- add a Playwright spec that verifies toggled tasks remain checked after reloading the app

## Testing
- `pnpm --filter web test:unit -- --run`
- `pnpm --filter web test:e2e` *(fails: spawn /bin/sh ENOENT when running bddgen)*

------
https://chatgpt.com/codex/tasks/task_e_68d663f77ec88329ae242e1a2bdff159