### PR TITLE
feat: restyle app shell with DaisyUI

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -33,6 +33,7 @@
     "@testing-library/svelte": "5.2.8",
     "@testing-library/user-event": "14.6.1",
     "@types/node": "^22.18.6",
+    "daisyui": "^4.12.24",
     "@typescript-eslint/parser": "8.44.1",
     "@vitest/browser": "^3.2.3",
     "eslint": "^9.22.0",

--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -1,2 +1,11 @@
 @import 'tailwindcss';
 @plugin '@tailwindcss/typography';
+@plugin 'daisyui';
+
+:root {
+    color-scheme: light dark;
+}
+
+body {
+    @apply min-h-screen bg-base-200 text-base-content;
+}

--- a/apps/web/src/lib/app-shell/AppShell.svelte
+++ b/apps/web/src/lib/app-shell/AppShell.svelte
@@ -39,61 +39,55 @@
     };
 </script>
 
-<div class="app-shell" data-layout={layout} data-mode={viewMode}>
+<div
+    class="flex min-h-screen flex-col bg-base-200/80 text-base-content"
+    data-layout={layout}
+    data-mode={viewMode}
+>
     <Toolbar {version} />
-    <main class="panels" data-layout={layout}>
-        <section class="panel editor" aria-label={panelLabels.editor} hidden={!showEditor}>
-            <slot name="editor" />
+    <main
+        class={`grid flex-1 gap-4 p-4 transition-all duration-300 ${
+            layout === "desktop"
+                ? "grid-cols-[minmax(0,1fr)_minmax(0,1fr)]"
+                : "grid-cols-1"
+        }`}
+        data-layout={layout}
+    >
+        <section
+            class={`card h-full overflow-hidden border border-base-300/60 bg-base-100 shadow-sm transition-all duration-300 ${
+                showEditor ? "opacity-100" : "opacity-0"
+            }`}
+            aria-label={panelLabels.editor}
+            hidden={!showEditor}
+            data-panel="editor"
+        >
+            <div class="card-body h-full gap-0 overflow-hidden p-0">
+                <slot name="editor" />
+            </div>
         </section>
-        <section class="panel preview" aria-label={panelLabels.preview} hidden={!showPreview}>
-            <slot name="preview" />
+        <section
+            class={`card h-full overflow-hidden border border-base-300/60 bg-base-100 shadow-sm transition-all duration-300 ${
+                showPreview ? "opacity-100" : "opacity-0"
+            }`}
+            aria-label={panelLabels.preview}
+            hidden={!showPreview}
+            data-panel="preview"
+        >
+            <div class="card-body h-full gap-0 overflow-hidden p-0">
+                <slot name="preview" />
+            </div>
         </section>
-        <section class="panel settings" aria-label={panelLabels.settings} hidden={!showSettings}>
-            <slot name="settings" />
+        <section
+            class={`card h-full overflow-hidden border border-base-300/60 bg-base-100 shadow-sm transition-all duration-300 ${
+                showSettings ? "opacity-100" : "opacity-0"
+            }`}
+            aria-label={panelLabels.settings}
+            hidden={!showSettings}
+            data-panel="settings"
+        >
+            <div class="card-body h-full gap-0 overflow-hidden p-0">
+                <slot name="settings" />
+            </div>
         </section>
     </main>
 </div>
-
-<style>
-    .app-shell {
-        display: flex;
-        flex-direction: column;
-        min-height: 100vh;
-        background: var(--app-shell-bg, #f3f4f6);
-        color: var(--app-shell-fg, #111827);
-    }
-
-    .panels {
-        flex: 1;
-        display: grid;
-        grid-template-columns: 1fr;
-        gap: 0;
-        overflow: hidden;
-    }
-
-    .panels[data-layout="desktop"] {
-        grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
-    }
-
-    .panel {
-        display: flex;
-        flex-direction: column;
-        background: #ffffff;
-        border-right: 1px solid #e5e7eb;
-        overflow: hidden;
-    }
-
-    .panel:last-child {
-        border-right: none;
-    }
-
-    .panel[hidden] {
-        display: none;
-    }
-
-    @media (max-width: 960px) {
-        .panels[data-layout="mobile"] {
-            grid-template-columns: minmax(0, 1fr);
-        }
-    }
-</style>

--- a/apps/web/src/lib/app-shell/SaveIndicator.svelte
+++ b/apps/web/src/lib/app-shell/SaveIndicator.svelte
@@ -11,87 +11,51 @@
     const errorTooltip =
         "We couldn't save locally. Retry or export your data to keep a copy while we work on cloud sync.";
     $: tooltipMessage = status.kind === "error" ? errorTooltip : localSaveTooltip;
+
+    type ToneClasses = { container: string; badge: string };
+
+    $: tone = (() => {
+        const base: ToneClasses = {
+            container: "border-success/60 bg-success/10 text-success",
+            badge: "badge-success"
+        };
+        if (status.kind === "error") {
+            return { container: "border-error/60 bg-error/10 text-error", badge: "badge-error" } satisfies ToneClasses;
+        }
+        if (status.kind === "saving") {
+            return { container: "border-info/60 bg-info/10 text-info", badge: "badge-info" } satisfies ToneClasses;
+        }
+        return base;
+    })();
+
+    $: containerClasses = [
+        "flex items-center gap-2 rounded-full border px-4 py-2 text-sm shadow-sm backdrop-blur transition-all duration-300",
+        tone.container
+    ].join(" ");
+
+    $: badgeClasses = [
+        "badge badge-xs border-0",
+        tone.badge,
+        status.kind === "saving" ? "animate-pulse" : ""
+    ]
+        .filter(Boolean)
+        .join(" ");
 </script>
 
-<div
-    class="save-indicator"
-    data-kind={status.kind}
-    aria-live="polite"
-    title={tooltipMessage}
-    aria-label={`${statusLabel}. ${tooltipMessage}`}
->
-    <span class="pulse" aria-hidden="true"></span>
-    <span class="message">{statusLabel}</span>
-    {#if timestampLabel && status.kind === "saved"}
-        <span class="timestamp">({timestampLabel})</span>
-    {/if}
-    <span class="tooltip-trigger" tabindex="0" role="img" aria-label={tooltipMessage} title={tooltipMessage}>ⓘ</span>
+<div class="tooltip tooltip-bottom w-full md:w-auto" data-tip={tooltipMessage}>
+    <div
+        class={containerClasses}
+        data-kind={status.kind}
+        aria-live="polite"
+        title={tooltipMessage}
+        aria-label={`${statusLabel}. ${tooltipMessage}`}
+        tabindex="0"
+    >
+        <span class={badgeClasses} aria-hidden="true"></span>
+        <span class="font-medium">{statusLabel}</span>
+        {#if timestampLabel && status.kind === "saved"}
+            <span class="text-xs text-base-content/60">({timestampLabel})</span>
+        {/if}
+        <span class="text-xs text-base-content/50" aria-hidden="true">ⓘ</span>
+    </div>
 </div>
-
-<style>
-    .save-indicator {
-        display: inline-flex;
-        align-items: center;
-        gap: 0.35rem;
-        font-size: 0.85rem;
-        color: #111827;
-    }
-
-    .save-indicator[data-kind="saving"] .pulse {
-        animation: pulse 1s infinite;
-        background: #2563eb;
-    }
-
-    .save-indicator[data-kind="saved"] .pulse {
-        background: #059669;
-    }
-
-    .save-indicator[data-kind="error"] {
-        color: #b91c1c;
-    }
-
-    .save-indicator[data-kind="error"] .pulse {
-        background: #b91c1c;
-    }
-
-    .pulse {
-        width: 0.55rem;
-        height: 0.55rem;
-        border-radius: 50%;
-        background: #6b7280;
-    }
-
-    @keyframes pulse {
-        0% {
-            opacity: 0.4;
-        }
-        50% {
-            opacity: 1;
-        }
-        100% {
-            opacity: 0.4;
-        }
-    }
-
-    .timestamp {
-        color: #6b7280;
-        font-size: 0.75rem;
-    }
-
-    .tooltip-trigger {
-        font-size: 0.85rem;
-        color: #6b7280;
-        cursor: help;
-    }
-
-    .tooltip-trigger:hover,
-    .tooltip-trigger:focus {
-        color: #2563eb;
-    }
-
-    .tooltip-trigger:focus {
-        outline: 2px solid #2563eb;
-        outline-offset: 2px;
-        border-radius: 9999px;
-    }
-</style>

--- a/apps/web/src/lib/app-shell/Toolbar.svelte
+++ b/apps/web/src/lib/app-shell/Toolbar.svelte
@@ -26,20 +26,45 @@
     function handlePanelChange(id: PanelId) {
         activatePanel(id);
     }
+
+    function viewButtonClasses(id: ViewMode): string {
+        return [
+            "btn btn-sm join-item font-medium transition-colors duration-200",
+            $shellState.viewMode === id
+                ? "btn-primary shadow"
+                : "btn-ghost text-base-content/70 hover:text-base-content"
+        ].join(" ");
+    }
+
+    function panelButtonClasses(id: PanelId): string {
+        const isActive = $shellState.activePanel === id;
+        return [
+            "btn btn-sm join-item font-medium transition-colors duration-200",
+            isActive ? "btn-secondary shadow" : "btn-ghost text-base-content/70 hover:text-base-content",
+            !isPanelAllowedInMode(id, $shellState.viewMode) ? "btn-disabled opacity-40" : ""
+        ]
+            .filter(Boolean)
+            .join(" ");
+    }
 </script>
 
-<header class="toolbar">
-    <div class="branding">
-        <h1>Kelpie</h1>
-        <span class="version">{version}</span>
+<header class="navbar sticky top-0 z-30 border-b border-base-300 bg-base-100/95 px-4 backdrop-blur">
+    <div class="navbar-start flex-col items-start gap-3 py-3 md:flex-row md:items-center">
+        <div class="flex items-center gap-3">
+            <span class="text-2xl font-black tracking-tight text-primary">Kelpie</span>
+            <span class="badge badge-outline badge-sm">{version}</span>
+        </div>
+        <p class="text-sm text-base-content/70">
+            Markdown to-do studio — edit, preview, and fine-tune your flow.
+        </p>
     </div>
 
-    <div class="controls">
-        <div class="view-selector" role="group" aria-label="Panel layout">
+    <div class="navbar-center flex flex-1 flex-col items-center gap-3 py-3 lg:flex-row lg:justify-center">
+        <div class="join join-horizontal" role="group" aria-label="Panel layout">
             {#each viewOptions as option}
                 <button
                     type="button"
-                    class:active={$shellState.viewMode === option.id}
+                    class={`${viewButtonClasses(option.id)} whitespace-nowrap`}
                     on:click={() => handleViewChange(option.id)}
                 >
                     {option.label}
@@ -48,11 +73,11 @@
         </div>
 
         {#if $shellState.layout === "mobile"}
-            <div class="panel-selector" role="group" aria-label="Active panel">
+            <div class="join join-horizontal" role="group" aria-label="Active panel">
                 {#each PANEL_ORDER as panel}
                     <button
                         type="button"
-                        class:active={$shellState.activePanel === panel}
+                        class={`${panelButtonClasses(panel)} whitespace-nowrap`}
                         disabled={!isPanelAllowedInMode(panel, $shellState.viewMode)}
                         on:click={() => handlePanelChange(panel)}
                     >
@@ -63,94 +88,7 @@
         {/if}
     </div>
 
-    <div class="status">
+    <div class="navbar-end py-3">
         <SaveIndicator />
     </div>
 </header>
-
-<style>
-    .toolbar {
-        display: flex;
-        align-items: center;
-        gap: 1.5rem;
-        padding: 0.75rem 1rem;
-        background: #111827;
-        color: #f9fafb;
-        border-bottom: 1px solid rgba(255, 255, 255, 0.08);
-        flex-wrap: wrap;
-    }
-
-    .branding {
-        display: flex;
-        align-items: baseline;
-        gap: 0.5rem;
-    }
-
-    h1 {
-        margin: 0;
-        font-size: 1.2rem;
-        letter-spacing: 0.02em;
-    }
-
-    .version {
-        font-size: 0.75rem;
-        color: rgba(249, 250, 251, 0.75);
-    }
-
-    .controls {
-        display: flex;
-        align-items: center;
-        gap: 1rem;
-        flex: 1;
-        min-width: 240px;
-    }
-
-    .view-selector,
-    .panel-selector {
-        display: inline-flex;
-        border-radius: 999px;
-        background: rgba(255, 255, 255, 0.08);
-        padding: 0.25rem;
-        gap: 0.25rem;
-    }
-
-    button {
-        border: none;
-        background: transparent;
-        color: inherit;
-        font: inherit;
-        padding: 0.35rem 0.75rem;
-        border-radius: 999px;
-        cursor: pointer;
-        transition: background 0.2s ease;
-    }
-
-    button:hover:not(:disabled) {
-        background: rgba(255, 255, 255, 0.12);
-    }
-
-    button.active {
-        background: #2563eb;
-    }
-
-    button:disabled {
-        opacity: 0.4;
-        cursor: not-allowed;
-    }
-
-    .status {
-        margin-left: auto;
-        min-width: 160px;
-    }
-
-    @media (max-width: 960px) {
-        .toolbar {
-            align-items: flex-start;
-        }
-
-        .status {
-            width: 100%;
-            margin-left: 0;
-        }
-    }
-</style>

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,9 +1,10 @@
 import { sveltekit } from "@sveltejs/kit/vite";
+import tailwindcss from "@tailwindcss/vite";
 import { defineConfig } from "vitest/config";
 import path from "node:path";
 
 export default defineConfig({
-  plugins: [sveltekit()],
+  plugins: [sveltekit(), tailwindcss()],
   test: {
     environment: "jsdom",
     globals: true,


### PR DESCRIPTION
## Summary
- integrate the DaisyUI plugin into the web workspace and expose it through Vite
- restyle the app shell layout, toolbar, and save indicator with DaisyUI cards, buttons, and badges
- refresh global styling defaults for the shell background and typography

## Testing
- pnpm --filter web test:unit -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d663bde62c8329a34f033daa78db16