### PR TITLE
Document storage architecture and wire UI to storage engine

### DIFF
--- a/apps/web/src/lib/stores/state.ts
+++ b/apps/web/src/lib/stores/state.ts
@@ -1,86 +1,226 @@
-import { browser } from "$app/environment";
-import { writable, derived } from "svelte/store";
+import { derived } from "svelte/store";
 import { parseMarkdown, formatTask, type Task } from "../parsing/parseTask";
 import { markError, markSaved, markSaving } from "./persistence";
+import {
+    createStorageEngine,
+    type DocumentIndexEntry,
+    type DocumentSnapshot,
+    type StorageSnapshot
+} from "./storage";
 
 export type PersistedState = {
+    documentId: string;
     file: string;
     ui: {
         panes: Record<string, boolean>;
         activeFilters: Record<string, unknown>;
     };
-    meta: { version: 1; migratedFrom?: string };
+    meta: {
+        version: number;
+        documentTitle: string;
+        documentUpdatedAt: string | null;
+    };
 };
-
-const KEY = "kelpie.todo.mmd:v1";
 
 const defaultFile = `- [ ] Buy milk @due(2025-10-31) #groceries
 - [x] Wash car @done(2025-09-01)`;
 
-const defaultState: PersistedState = {
-    file: defaultFile,
-    ui: { panes: {}, activeFilters: {} },
-    meta: { version: 1 }
-};
+const PRIMARY_DOCUMENT_ID = "kelpie-primary-document";
+const PRIMARY_DOCUMENT_TITLE = "My tasks";
 
-function load(): PersistedState {
-    if (!browser) {
-        return defaultState;
+const storage = createStorageEngine();
+
+function ensurePrimaryDocument(snapshot: StorageSnapshot): StorageSnapshot {
+    const now = new Date().toISOString();
+    let documents = snapshot.documents;
+    let index = snapshot.index;
+    let settings = snapshot.settings;
+    let changed = false;
+
+    const activeId = settings.lastActiveDocumentId;
+    let targetId = PRIMARY_DOCUMENT_ID;
+
+    if (typeof activeId === "string" && documents[activeId]) {
+        targetId = activeId;
     }
-    try {
-        const raw = localStorage.getItem(KEY);
-        if (!raw) return defaultState;
 
-        const parsed: unknown = JSON.parse(raw);
-        if (
-            typeof parsed === "object" &&
-            parsed !== null &&
-            "file" in parsed &&
-            typeof (parsed as { file: unknown }).file === "string"
-        ) {
-            return parsed as PersistedState;
+    if (!documents[targetId]) {
+        const createdAt = now;
+        const document: DocumentSnapshot = {
+            id: targetId,
+            title: PRIMARY_DOCUMENT_TITLE,
+            content: defaultFile,
+            createdAt,
+            updatedAt: createdAt
+        };
+        documents = { ...documents, [targetId]: document };
+        changed = true;
+    }
+
+    const resolvedDocument = documents[targetId];
+    if (!resolvedDocument) {
+        return snapshot;
+    }
+    const entryIndex = index.findIndex((entry) => entry.id === targetId);
+
+    if (entryIndex === -1) {
+        const entry: DocumentIndexEntry = {
+            id: targetId,
+            title: resolvedDocument.title,
+            createdAt: resolvedDocument.createdAt,
+            updatedAt: resolvedDocument.updatedAt,
+            deletedAt: null,
+            purgeAfter: null
+        };
+        index = [...index, entry];
+        changed = true;
+    } else {
+        const currentEntry = index[entryIndex]!;
+        const shouldRestore =
+            currentEntry.deletedAt !== null ||
+            currentEntry.purgeAfter !== null ||
+            currentEntry.title !== resolvedDocument.title;
+        if (shouldRestore) {
+            const updatedEntry: DocumentIndexEntry = {
+                ...currentEntry,
+                title: resolvedDocument.title,
+                updatedAt: resolvedDocument.updatedAt,
+                deletedAt: null,
+                purgeAfter: null
+            };
+            index = [
+                ...index.slice(0, entryIndex),
+                updatedEntry,
+                ...index.slice(entryIndex + 1)
+            ];
+            changed = true;
         }
-        return defaultState;
-    } catch {
-        return defaultState;
     }
+
+    if (settings.lastActiveDocumentId !== targetId) {
+        settings = { ...settings, lastActiveDocumentId: targetId, updatedAt: now };
+        changed = true;
+    } else if (changed) {
+        settings = { ...settings, updatedAt: now };
+    }
+
+    return changed
+        ? {
+              ...snapshot,
+              documents,
+              index,
+              settings
+          }
+        : snapshot;
 }
 
-export const appState = writable<PersistedState>(load());
+storage.update(ensurePrimaryDocument);
 
-if (browser) {
-    appState.subscribe((state) => {
-        try {
-            markSaving();
-            localStorage.setItem(KEY, JSON.stringify(state));
-            queueMicrotask(markSaved);
-        } catch (error) {
-            markError(error);
+export const appState = derived(storage.snapshot, ($snapshot): PersistedState => {
+    const activeId = $snapshot.settings.lastActiveDocumentId ?? PRIMARY_DOCUMENT_ID;
+    const activeDocument = $snapshot.documents[activeId];
+
+    return {
+        documentId: activeId,
+        file: activeDocument?.content ?? defaultFile,
+        ui: {
+            panes: $snapshot.settings.panes,
+            activeFilters: $snapshot.settings.filters
+        },
+        meta: {
+            version: $snapshot.meta.version,
+            documentTitle: activeDocument?.title ?? PRIMARY_DOCUMENT_TITLE,
+            documentUpdatedAt: activeDocument?.updatedAt ?? null
         }
-    });
-}
+    };
+});
 
 /**
  * Derived store: parse tasks from Markdown file.
  */
 export const tasks = derived(appState, ($s) => parseMarkdown($s.file));
 
+function commitUpdate(updater: (snapshot: StorageSnapshot) => StorageSnapshot): void {
+    markSaving();
+    try {
+        storage.update(updater);
+        queueMicrotask(markSaved);
+    } catch (error) {
+        markError(error);
+    }
+}
+
+function updateActiveDocument(
+    reducer: (document: DocumentSnapshot, snapshot: StorageSnapshot) => DocumentSnapshot
+): void {
+    commitUpdate((snapshot) => {
+        const documentId = snapshot.settings.lastActiveDocumentId ?? PRIMARY_DOCUMENT_ID;
+        const existing = snapshot.documents[documentId];
+
+        if (!existing) {
+            return snapshot;
+        }
+
+        const nextDocument = reducer(existing, snapshot);
+        if (nextDocument === existing) {
+            return snapshot;
+        }
+
+        const now = new Date().toISOString();
+        const documentWithTimestamps: DocumentSnapshot = {
+            ...existing,
+            ...nextDocument,
+            id: existing.id,
+            createdAt: existing.createdAt,
+            updatedAt: now
+        };
+
+        const updatedIndex = snapshot.index.map((entry) =>
+            entry.id === documentId
+                ? {
+                      ...entry,
+                      title: documentWithTimestamps.title,
+                      updatedAt: now,
+                      deletedAt: null,
+                      purgeAfter: null
+                  }
+                : entry
+        );
+
+        return {
+            ...snapshot,
+            documents: { ...snapshot.documents, [documentId]: documentWithTimestamps },
+            index: updatedIndex,
+            settings: { ...snapshot.settings, updatedAt: now }
+        };
+    });
+}
+
+export function setDocumentContent(content: string): void {
+    updateActiveDocument((document) => {
+        if (document.content === content) {
+            return document;
+        }
+        return { ...document, content };
+    });
+}
+
 /**
  * Toggle a task's checked state by id.
  */
 export function toggleTask(id: string): void {
-    appState.update((s) => {
-        const lines = s.file.split(/\r?\n/);
-        const parsed = parseMarkdown(s.file);
+    updateActiveDocument((document) => {
+        const lines = document.content.split(/\r?\n/);
+        const parsed = parseMarkdown(document.content);
         const idx = parsed.findIndex((t) => t.id === id);
 
         if (idx === -1) {
-            return s; // nothing to toggle
+            return document; // nothing to toggle
         }
 
         const t = parsed[idx];
         if (!t) {
-            return s; // extra guard (strict mode safe)
+            return document; // extra guard (strict mode safe)
         }
 
         const updated: Task = {
@@ -93,6 +233,6 @@ export function toggleTask(id: string): void {
 
         lines[idx] = formatTask(updated);
 
-        return { ...s, file: lines.join("\n") };
+        return { ...document, content: lines.join("\n") };
     });
 }

--- a/apps/web/src/lib/stores/storage/README.md
+++ b/apps/web/src/lib/stores/storage/README.md
@@ -1,0 +1,50 @@
+# Storage architecture
+
+Kelpie's web app persists editor data through a small storage engine that wraps
+Svelte stores around a serialised snapshot. The goals are:
+
+- keep the UI reactive by exposing read-only stores,
+- isolate persistence details behind a driver abstraction, and
+- centralise schema/metadata logic for future features such as history,
+  multi-document support, and cross-tab synchronisation.
+
+## Modules and responsibilities
+
+| Module | Responsibility |
+| --- | --- |
+| [`constants.ts`](./constants.ts) | Defines schema version numbers and default caps used across the storage layer. |
+| [`types.ts`](./types.ts) | Declares the snapshot schema (installation meta, configuration, settings, document index, history, audit trails). |
+| [`defaults.ts`](./defaults.ts) | Builds default runtime configuration, UI settings, and the initial snapshot that seeds a new installation. |
+| [`driver.ts`](./driver.ts) | Wraps the host persistence API. The default driver uses `localStorage` but any alternative (memory, IndexedDB, remote APIs) can be swapped in. The driver also exposes a `subscribe` hook so the engine can react to external writes (e.g. storage events from other tabs). |
+| [`engine.ts`](./engine.ts) | Turns snapshots into writable Svelte stores (`snapshot`, `config`, `settings`) and exposes lifecycle helpers (`refresh`, `reset`, `update`). The engine coordinates with the driver, applying mutations and keeping derived stores in sync. |
+| [`index.ts`](./index.ts) | Convenience barrel export for the storage subsystem. |
+
+## Data flow at runtime
+
+1. `state.ts` creates a storage engine instance at module load. On startup it calls
+   `storage.update(ensurePrimaryDocument)` to guarantee that a primary document
+   exists and that UI settings point at it.
+2. Components read `appState` (a derived store) for the active document content
+   and UI flags, and `tasks` (a derived store that parses the Markdown file).
+3. Mutations go through helper functions:
+   - `setDocumentContent` writes the editor value.
+   - `toggleTask` re-renders a Markdown line when the preview toggles a task.
+   Both helpers delegate to `updateActiveDocument`, which calls
+   `storage.update(...)` with a new snapshot. The storage engine persists the
+   snapshot via the driver and updates the derived stores.
+4. `persistence.ts` is notified of each mutation (`markSaving` before the write
+   and `markSaved` afterwards) so the toolbar can surface save status to the user.
+
+## Why this split?
+
+- **Testability:** the driver abstraction makes it trivial to plug in a
+  deterministic in-memory driver for unit tests.
+- **Future features:** configuration, audit, and history data live alongside the
+  document content. Upcoming tasks can extend the schema without touching the UI
+  surface area.
+- **Cross-tab support:** `driver.subscribe` gives the engine a single place to
+  react to external writes (BroadcastChannel, `storage` events, etc.) without the
+  UI knowing about transport details.
+
+With this wiring the UI stays simple—components only consume Svelte stores—while
+all persistence behaviour is owned by the storage engine and its driver.

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -3,12 +3,12 @@
     import CodeEditorPanel from "$lib/panels/editor/CodeEditorPanel.svelte";
     import InteractivePreviewPanel from "$lib/panels/preview/InteractivePreviewPanel.svelte";
     import AppSettingsPanel from "$lib/panels/settings/AppSettingsPanel.svelte";
-    import { appState, tasks, toggleTask } from "$lib/stores/state";
+    import { appState, setDocumentContent, tasks, toggleTask } from "$lib/stores/state";
 
     const version = "0.0.0-dev";
 
     function handleEditorChange(event: CustomEvent<{ value: string }>) {
-        appState.update((state) => ({ ...state, file: event.detail.value }));
+        setDocumentContent(event.detail.value);
     }
 
     function handleToggle(event: CustomEvent<{ id: string }>) {


### PR DESCRIPTION
## Summary
- add a storage README that documents the engine, driver, and state integration
- extend the storage engine with an update helper that keeps derived stores in sync
- refactor the Svelte state store and route to read/write via the storage engine instead of direct localStorage

## Testing
- pnpm --filter web check *(fails: existing svelte-check errors in SaveIndicator.svelte, shell.ts, and AppSettingsPanel.svelte)*

------
https://chatgpt.com/codex/tasks/task_e_68d663d32b688329a14d1430ddeca3f7