### PR TITLE
Implement workflow helpers for specs and E2E caching

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,34 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "pnpm dev",
+      "type": "shell",
+      "command": "pnpm dev",
+      "group": "build",
+      "isBackground": true,
+      "problemMatcher": []
+    },
+    {
+      "label": "pnpm dev:specs",
+      "type": "shell",
+      "command": "pnpm dev:specs",
+      "group": "build",
+      "isBackground": true,
+      "problemMatcher": []
+    },
+    {
+      "label": "pnpm test:unit:watch",
+      "type": "shell",
+      "command": "pnpm test:unit:watch",
+      "isBackground": true,
+      "problemMatcher": []
+    },
+    {
+      "label": "pnpm test:e2e",
+      "type": "shell",
+      "command": "pnpm test:e2e",
+      "problemMatcher": []
+    }
+  ]
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,9 +13,10 @@
     "format": "prettier --write . --cache --cache-location ../../.cache/prettier",
     "lint": "prettier --check . --cache --cache-location ../../.cache/prettier && eslint . --cache --cache-location ../../.cache/eslint",
     "test:unit": "vitest",
+    "test:unit:watch": "vitest --watch",
     "test": "npm run test:unit -- --run && npm run test:e2e",
     "test:e2e:generate": "bddgen",
-    "test:e2e": "pnpm spec:extract && bddgen && playwright test",
+    "test:e2e": "node ../../scripts/run-playwright-e2e.js",
     "spec:extract": "node src/lib/specdsl/extract.js"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "ai:refactor": "node scripts/ai-refactor.js",
     "test:e2e:all": "node scripts/run-e2e.js --browsers=chromium,webkit",
     "spec:extract:watch": "node scripts/spec-watch.js",
+    "dev:specs": "node scripts/dev-with-specs.js",
     "prepare": "node scripts/setup-hooks.js"
   },
   "lint-staged": {

--- a/scripts/dev-with-specs.js
+++ b/scripts/dev-with-specs.js
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+const { spawn } = require("child_process");
+
+const processes = [];
+let shuttingDown = false;
+
+function run(command, args) {
+  const child = spawn(command, args, {
+    stdio: "inherit",
+    shell: process.platform === "win32"
+  });
+
+  processes.push(child);
+
+  child.on("exit", (code, signal) => {
+    if (shuttingDown) {
+      return;
+    }
+
+    shuttingDown = true;
+
+    // If one of the processes exits, terminate the rest and exit with the same code.
+    for (const proc of processes) {
+      if (proc !== child && !proc.killed) {
+        proc.kill("SIGINT");
+      }
+    }
+
+    if (signal) {
+      process.kill(process.pid, signal);
+    } else {
+      process.exit(code ?? 1);
+    }
+  });
+
+  return child;
+}
+
+function shutdown() {
+  if (shuttingDown) return;
+  shuttingDown = true;
+
+  for (const child of processes) {
+    if (!child.killed) {
+      child.kill("SIGINT");
+    }
+  }
+}
+
+process.once("SIGINT", shutdown);
+process.once("SIGTERM", shutdown);
+process.once("exit", shutdown);
+
+run("pnpm", ["dev"]);
+run("pnpm", ["spec:extract:watch"]);

--- a/scripts/run-playwright-e2e.js
+++ b/scripts/run-playwright-e2e.js
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+const { spawn } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
+const projectRoot = path.resolve(__dirname, "..");
+const featureDir = path.resolve(projectRoot, "apps/web/e2e/features");
+const generatedDir = path.resolve(projectRoot, "apps/web/e2e/steps/generated");
+const cacheDir = path.resolve(projectRoot, ".cache");
+const stampFile = path.join(cacheDir, "bddgen.timestamp");
+
+function run(command, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      stdio: "inherit",
+      shell: process.platform === "win32",
+      ...options
+    });
+
+    child.on("exit", (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`${command} ${args.join(" ")} exited with code ${code}`));
+      }
+    });
+  });
+}
+
+function ensureCacheDir() {
+  if (!fs.existsSync(cacheDir)) {
+    fs.mkdirSync(cacheDir, { recursive: true });
+  }
+}
+
+function latestFeatureTimestamp() {
+  if (!fs.existsSync(featureDir)) {
+    return 0;
+  }
+
+  const stack = [featureDir];
+  let latest = 0;
+
+  while (stack.length) {
+    const current = stack.pop();
+    const entries = fs.readdirSync(current, { withFileTypes: true });
+
+    for (const entry of entries) {
+      const fullPath = path.join(current, entry.name);
+
+      if (entry.isDirectory()) {
+        stack.push(fullPath);
+        continue;
+      }
+
+      if (entry.isFile() && path.extname(entry.name) === ".feature") {
+        const stats = fs.statSync(fullPath);
+        latest = Math.max(latest, stats.mtimeMs);
+      }
+    }
+  }
+
+  return latest;
+}
+
+function needsGeneration(latestTimestamp) {
+  if (!fs.existsSync(generatedDir)) {
+    return true;
+  }
+
+  if (!fs.existsSync(stampFile)) {
+    return true;
+  }
+
+  const cachedValue = Number.parseFloat(fs.readFileSync(stampFile, "utf8"));
+  if (Number.isNaN(cachedValue)) {
+    return true;
+  }
+
+  return latestTimestamp > cachedValue;
+}
+
+async function maybeGenerateSteps() {
+  const latestTimestamp = latestFeatureTimestamp();
+  if (!needsGeneration(latestTimestamp)) {
+    return;
+  }
+
+  await run("pnpm", ["--filter", "web", "test:e2e:generate"], { cwd: projectRoot });
+
+  ensureCacheDir();
+  const timestampToPersist = latestTimestamp || Date.now();
+  fs.writeFileSync(stampFile, String(timestampToPersist));
+}
+
+async function main() {
+  await run("pnpm", ["spec:extract"], { cwd: projectRoot });
+  await maybeGenerateSteps();
+  await run("pnpm", ["--filter", "web", "exec", "playwright", "test"], {
+    cwd: projectRoot,
+    env: { ...process.env }
+  });
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exit(1);
+});

--- a/specs/developer-experience-improvements.md
+++ b/specs/developer-experience-improvements.md
@@ -1,0 +1,22 @@
+# Developer Experience Improvements
+
+## Context
+Kelpie already leans on a spec-driven workflow with dedicated scripts for formatting, linting, spec extraction, unit tests, and Playwright BDD flows. The suggestions below focus on tying those pieces together so contributors can move faster with fewer manual steps.
+
+## Suggestions
+
+### 1. Offer a "spec-aware" dev loop
+*Observation.* The workspace exposes `dev` and `spec:extract:watch` scripts separately; the latter spawns the Markdown extractor whenever specs change.
+*Recommendation.* Add a convenience script (for example `pnpm dev:specs`) that runs the SvelteKit dev server alongside `spec:extract:watch` using `pnpm --parallel` or a lightweight process manager. That keeps the generated feature files in sync during feature work without an extra terminal tab.
+
+### 2. Restore a real `test:unit:watch` target
+*Observation.* The root `test:unit:watch` script proxies to the `web` package, but `apps/web/package.json` does not currently define a matching command.
+*Recommendation.* Add a `test:unit:watch` script in `apps/web/package.json` that runs `vitest --watch` (or `vitest --ui`). This lines up the root script with the package-level tooling and gives contributors an easy long-running unit test loop.
+
+### 3. Speed up Playwright BDD runs with cached generation
+*Observation.* The `web` package’s `test:e2e` script regenerates cucumber step definitions on every run via `bddgen` before launching Playwright.
+*Recommendation.* Wrap `bddgen` in a simple timestamp-aware cache (for example, only regenerate when feature files under `e2e/` change) so local reruns skip the expensive generation step. That could live in `scripts/run-e2e.js` alongside the existing browser selection logic.
+
+### 4. Codify common dev tasks for editors
+*Observation.* The repo already defines VS Code defaults for formatting and ESLint, but there are no workspace tasks that mirror the pnpm scripts.
+*Recommendation.* Add a `.vscode/tasks.json` that exposes shortcuts for `pnpm dev`, `pnpm dev:specs`, `pnpm test:unit:watch`, and `pnpm test:e2e`. This gives contributors single-keystroke access to the common loops and keeps the project’s recommended workflows visible.


### PR DESCRIPTION
## Summary
- add a combined `dev:specs` script and editor tasks for common pnpm workflows
- provide a Vitest watch script in the web app and move e2e orchestration to a cached helper

## Testing
- pnpm --filter web test:unit -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d664e3f0088329b6d99c2d5b3ac321