### PR TITLE
Expand app shell spec and add save indicator tests

### DIFF
--- a/apps/web/e2e/features/app-web-shell.spec.1.feature
+++ b/apps/web/e2e/features/app-web-shell.spec.1.feature
@@ -1,0 +1,17 @@
+Feature: Save indicator communicates persistence state
+  Scenario: Saving state pulses with info tone
+    Given the app shell begins an offline save
+    When the save status is updated to "saving"
+    Then the indicator shows "Saving locally…" with a pulsing badge
+    And it reports the info tone styling
+
+  Scenario: Saved state reports the last save time
+    Given the save status is updated to "saved" with timestamp "2024-06-01T12:00:00Z"
+    Then the indicator shows "Saved locally ✓"
+    And it displays the formatted time in parentheses after the label
+
+  Scenario: Error state surfaces retry guidance
+    Given the save status is updated to "error" with message "Disk full"
+    Then the indicator shows "Disk full"
+    And the tooltip explains how to retry or export the data
+

--- a/apps/web/src/lib/app-shell/SaveIndicator.svelte
+++ b/apps/web/src/lib/app-shell/SaveIndicator.svelte
@@ -39,6 +39,7 @@
 </script>
 
 <div class="tooltip tooltip-bottom w-full md:w-auto" data-tip={tooltipMessage}>
+  <!-- svelte-ignore a11y-no-noninteractive-tabindex -->
   <div
     class={containerClasses}
     data-kind={status.kind}

--- a/apps/web/src/lib/app-shell/SaveIndicator.test.ts
+++ b/apps/web/src/lib/app-shell/SaveIndicator.test.ts
@@ -1,0 +1,70 @@
+import { render, screen, within } from "@testing-library/svelte";
+import { tick } from "svelte";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import SaveIndicator from "./SaveIndicator.svelte";
+import { markError, markSaved, markSaving, resetSaveStatus } from "$lib/stores/persistence";
+
+const localTooltip =
+  "Changes are stored locally on this device for now. Cloud sync will be introduced in a future release.";
+const errorTooltip = "We couldn't save locally. Retry or export your data to keep a copy while we work on cloud sync.";
+
+describe("SaveIndicator", () => {
+  afterEach(() => {
+    resetSaveStatus();
+    vi.useRealTimers();
+  });
+
+  it("renders idle state with local save guidance", () => {
+    render(SaveIndicator);
+
+    const indicator = screen.getByLabelText(/Saved locally/);
+    expect(indicator).toHaveAttribute("data-kind", "idle");
+    expect(indicator).toHaveAttribute("title", localTooltip);
+    expect(within(indicator).getByText("Saved locally ✓")).toBeVisible();
+    expect(
+      screen.queryByText((content) => content.startsWith("(") && content.includes(":") && content.endsWith(")"))
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows saving state with pulsing badge", async () => {
+    render(SaveIndicator);
+
+    markSaving();
+    await tick();
+
+    const indicator = screen.getByLabelText(/Saving locally/);
+    expect(indicator).toHaveAttribute("data-kind", "saving");
+    expect(indicator).toHaveAttribute("title", localTooltip);
+    const label = within(indicator).getByText("Saving locally…");
+    expect(label).toBeVisible();
+    const badge = indicator.querySelector(".badge");
+    expect(badge?.className).toContain("animate-pulse");
+  });
+
+  it("shows saved timestamp when persistence succeeds", async () => {
+    render(SaveIndicator);
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-06-01T12:00:00Z"));
+
+    markSaved();
+    await tick();
+
+    const indicator = screen.getByLabelText(/Saved locally/);
+    expect(indicator).toHaveAttribute("data-kind", "saved");
+    const timestamp = screen.getByText((content) => content.startsWith("(") && content.endsWith(")"));
+    expect(timestamp.textContent).toContain(":");
+  });
+
+  it("surfaces errors with retry tooltip", async () => {
+    render(SaveIndicator);
+
+    markError(new Error("Disk full"));
+    await tick();
+
+    const indicator = screen.getByLabelText(/Disk full/);
+    expect(indicator).toHaveAttribute("data-kind", "error");
+    expect(indicator).toHaveAttribute("title", errorTooltip);
+    expect(within(indicator).getByText("Disk full")).toBeVisible();
+  });
+});

--- a/apps/web/src/lib/stores/persistence.test.ts
+++ b/apps/web/src/lib/stores/persistence.test.ts
@@ -1,0 +1,61 @@
+import { get } from "svelte/store";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { markError, markSaved, markSaving, resetSaveStatus, saveStatus } from "./persistence";
+
+describe("persistence saveStatus store", () => {
+  afterEach(() => {
+    resetSaveStatus();
+    vi.useRealTimers();
+  });
+
+  it("starts idle with saved messaging", () => {
+    const status = get(saveStatus);
+    expect(status).toEqual({ kind: "idle", message: "Saved locally \u2713", timestamp: null });
+  });
+
+  it("records saving state with timestamp", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-04-01T08:00:00Z"));
+
+    markSaving();
+    const status = get(saveStatus);
+    expect(status.kind).toBe("saving");
+    expect(status.message).toBe("Saving locally\u2026");
+    expect(status.timestamp).toBe(Date.now());
+  });
+
+  it("records saved state with timestamp", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-04-01T08:05:00Z"));
+
+    markSaved();
+    const status = get(saveStatus);
+    expect(status.kind).toBe("saved");
+    expect(status.message).toBe("Saved locally \u2713");
+    expect(status.timestamp).toBe(Date.now());
+  });
+
+  it("captures error messages while timestamping", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-04-01T08:10:00Z"));
+
+    markError(new Error("Disk full"));
+    const status = get(saveStatus);
+    expect(status.kind).toBe("error");
+    expect(status.message).toBe("Disk full");
+    expect(status.timestamp).toBe(Date.now());
+  });
+
+  it("falls back to friendly error when unknown value provided", () => {
+    markError(42);
+    const status = get(saveStatus);
+    expect(status.message).toBe("Failed to save locally");
+  });
+
+  it("resetSaveStatus restores idle contract", () => {
+    markSaving();
+    resetSaveStatus();
+    const status = get(saveStatus);
+    expect(status).toEqual({ kind: "idle", message: "Saved locally \u2713", timestamp: null });
+  });
+});

--- a/apps/web/src/lib/stores/persistence.ts
+++ b/apps/web/src/lib/stores/persistence.ts
@@ -19,3 +19,7 @@ export function markError(error: unknown): void {
   const message = error instanceof Error ? error.message : typeof error === "string" ? error : "Failed to save locally";
   set({ kind: "error", message, timestamp: Date.now() });
 }
+
+export function resetSaveStatus(): void {
+  set(initialStatus);
+}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -10,6 +10,9 @@ export default defineConfig({
     setupFiles: ["./vitest.setup.ts"],
     include: ["src/**/*.{test,spec}.{js,ts}"]
   },
+  resolve: {
+    conditions: ["svelte", "browser"]
+  },
   server: {
     fs: {
       allow: [


### PR DESCRIPTION
## Summary
- extend the app shell spec with detailed save indicator UX and persistence store requirements, including Gherkin coverage
- generate the save indicator feature file and add a reset helper for the persistence store
- add Vitest coverage for the save indicator component and save status store while configuring Vitest to resolve browser builds

## Testing
- pnpm vitest run

------
https://chatgpt.com/codex/tasks/task_e_68d67719cf748329921ceb50d8e9a811