### PR TITLE
Add E2E coverage for app shell layout controls

### DIFF
--- a/apps/web/e2e/features/app-shell-layout.feature
+++ b/apps/web/e2e/features/app-shell-layout.feature
@@ -1,0 +1,29 @@
+Feature: App shell layout controls
+  Background:
+    Given I open the app with "basic.md"
+
+  Scenario: Switching to preview-only hides the editor on desktop
+    When I choose the "Preview" view mode
+    Then the "Code editor" panel should be hidden
+    And the "Preview" panel should be visible
+
+  Scenario: Switching to settings shows only the settings panel
+    When I choose the "Settings" view mode
+    Then the "Code editor" panel should be hidden
+    And the "Preview" panel should be hidden
+    And the "Settings" panel should be visible
+
+  Scenario: Mobile layout users can switch between panels
+    When I resize the viewport to "mobile"
+    Then the layout should be "mobile"
+    And the "Code editor" panel should be visible
+    And the "Preview" panel should be hidden
+    And the "Settings" panel should be hidden
+    When I switch to the "Preview" panel
+    Then the "Preview" panel should be visible
+    And the "Code editor" panel should be hidden
+    And the "Settings" panel should be hidden
+    When I choose the "Settings" view mode
+    Then the "Settings" panel should be visible
+    And the "Code editor" panel should be hidden
+    And the "Preview" panel should be hidden

--- a/apps/web/e2e/steps/shell.steps.ts
+++ b/apps/web/e2e/steps/shell.steps.ts
@@ -1,0 +1,60 @@
+import { expect, type Page } from "@playwright/test";
+import { createBdd } from "playwright-bdd";
+
+const { When, Then } = createBdd();
+
+const layoutSelector = "div[data-layout][data-mode]";
+
+When("I choose the {string} view mode", async ({ page }, label: string) => {
+  const button = page.getByRole("group", { name: "Panel layout" }).getByRole("button", { name: label, exact: true });
+
+  await expect(button).toBeVisible();
+  await button.click();
+});
+
+When("I switch to the {string} panel", async ({ page }, label: string) => {
+  const button = page.getByRole("group", { name: "Active panel" }).getByRole("button", { name: label, exact: true });
+
+  await expect(button).toBeVisible();
+  await expect(button).toBeEnabled();
+  await button.click();
+});
+
+When("I resize the viewport to {string}", async ({ page }, layout: string) => {
+  const normalized = layout.toLowerCase();
+  const viewport =
+    normalized === "mobile"
+      ? { width: 600, height: 900 }
+      : normalized === "desktop"
+        ? { width: 1280, height: 720 }
+        : null;
+
+  if (!viewport) {
+    throw new Error(`Unknown layout preset: ${layout}`);
+  }
+
+  await page.setViewportSize(viewport);
+
+  const targetLayout = normalized === "mobile" ? "mobile" : "desktop";
+  const shell = page.locator(layoutSelector).first();
+  await expect(shell).toHaveAttribute("data-layout", targetLayout);
+});
+
+Then("the layout should be {string}", async ({ page }, layout: string) => {
+  const shell = page.locator(layoutSelector).first();
+  await expect(shell).toHaveAttribute("data-layout", layout);
+});
+
+function panelLocator(page: Page, label: string) {
+  return page.getByRole("region", { name: label, exact: true });
+}
+
+Then("the {string} panel should be visible", async ({ page }, label: string) => {
+  const panel = panelLocator(page, label);
+  await expect(panel).toBeVisible();
+});
+
+Then("the {string} panel should be hidden", async ({ page }, label: string) => {
+  const panel = panelLocator(page, label);
+  await expect(panel).toBeHidden();
+});


### PR DESCRIPTION
## Summary
- add a BDD feature that exercises switching between app shell view modes and mobile panel navigation
- implement supporting Playwright step definitions for interacting with toolbar controls and layout state

## Testing
- pnpm test:e2e *(fails: Error: Failed to launch: spawn /bin/sh ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68d6773a4ce08329a7723db77e6edbba