### PR TITLE
feat: refresh workspace shell with mermaid-inspired styling

### DIFF
--- a/apps/web/src/lib/app-shell/AppShell.svelte
+++ b/apps/web/src/lib/app-shell/AppShell.svelte
@@ -37,47 +37,49 @@
   };
 </script>
 
-<div class="bg-base-200/80 text-base-content flex min-h-screen flex-col" data-layout={layout} data-mode={viewMode}>
+<div class="flex min-h-screen flex-col bg-base-200 text-base-content" data-layout={layout} data-mode={viewMode}>
   <Toolbar {version} />
   <main
-    class={`grid flex-1 gap-4 p-4 transition-all duration-300 ${
-      layout === "desktop" ? "grid-cols-[minmax(0,1fr)_minmax(0,1fr)]" : "grid-cols-1"
+    class={`grid w-full flex-1 gap-6 px-4 pb-8 pt-6 transition-all duration-300 sm:px-6 lg:mx-auto lg:max-w-6xl lg:px-8 ${
+      layout === "desktop" && viewMode !== "settings"
+        ? "lg:grid-cols-[minmax(0,1.05fr)_minmax(0,0.95fr)]"
+        : "grid-cols-1"
     }`}
     data-layout={layout}
   >
     <section
-      class={`card border-base-300/60 bg-base-100 h-full overflow-hidden border shadow-sm transition-all duration-300 ${
-        showEditor ? "opacity-100" : "opacity-0"
+      class={`flex h-full flex-col overflow-hidden rounded-3xl border border-base-300/70 bg-base-100/90 shadow-lg shadow-base-300/30 backdrop-blur transition-all duration-300 ${
+        showEditor ? "opacity-100" : "pointer-events-none opacity-0"
       }`}
       aria-label={panelLabels.editor}
       hidden={!showEditor}
       data-panel="editor"
     >
-      <div class="card-body h-full gap-0 overflow-hidden p-0">
+      <div class="flex h-full flex-col overflow-hidden">
         <slot name="editor" />
       </div>
     </section>
     <section
-      class={`card border-base-300/60 bg-base-100 h-full overflow-hidden border shadow-sm transition-all duration-300 ${
-        showPreview ? "opacity-100" : "opacity-0"
+      class={`flex h-full flex-col overflow-hidden rounded-3xl border border-base-300/70 bg-base-100/90 shadow-lg shadow-base-300/30 backdrop-blur transition-all duration-300 ${
+        showPreview ? "opacity-100" : "pointer-events-none opacity-0"
       }`}
       aria-label={panelLabels.preview}
       hidden={!showPreview}
       data-panel="preview"
     >
-      <div class="card-body h-full gap-0 overflow-hidden p-0">
+      <div class="flex h-full flex-col overflow-hidden">
         <slot name="preview" />
       </div>
     </section>
     <section
-      class={`card border-base-300/60 bg-base-100 h-full overflow-hidden border shadow-sm transition-all duration-300 ${
-        showSettings ? "opacity-100" : "opacity-0"
+      class={`flex h-full flex-col overflow-hidden rounded-3xl border border-base-300/70 bg-base-100/90 shadow-lg shadow-base-300/30 backdrop-blur transition-all duration-300 ${
+        showSettings ? "opacity-100" : "pointer-events-none opacity-0"
       }`}
       aria-label={panelLabels.settings}
       hidden={!showSettings}
       data-panel="settings"
     >
-      <div class="card-body h-full gap-0 overflow-hidden p-0">
+      <div class="flex h-full flex-col overflow-hidden">
         <slot name="settings" />
       </div>
     </section>

--- a/apps/web/src/lib/app-shell/Toolbar.svelte
+++ b/apps/web/src/lib/app-shell/Toolbar.svelte
@@ -4,11 +4,12 @@
   import SaveIndicator from "./SaveIndicator.svelte";
   import { PANEL_ORDER, type PanelId, type ViewMode, isPanelAllowedInMode } from "./contracts";
   import { activatePanel, setViewMode, shellState } from "$lib/stores/shell";
+  import { theme, toggleTheme } from "$lib/stores/theme";
 
   export let version: string;
 
   const viewOptions: { id: ViewMode; label: string }[] = [
-    { id: "editor-preview", label: "Editor + Preview" },
+    { id: "editor-preview", label: "Editor & preview" },
     { id: "preview-only", label: "Preview" },
     { id: "settings", label: "Settings" }
   ];
@@ -28,63 +29,188 @@
   }
 
   function viewButtonClasses(id: ViewMode): string {
+    const isActive = $shellState.viewMode === id;
     return [
-      "btn btn-sm join-item font-medium transition-colors duration-200",
-      $shellState.viewMode === id ? "btn-primary shadow" : "btn-ghost text-base-content/70 hover:text-base-content"
+      "dock-item btn btn-sm btn-circle border border-transparent bg-transparent text-base-content/70 transition-all duration-200",
+      isActive
+        ? "btn-primary text-primary-content shadow-sm"
+        : "hover:border-base-300 hover:bg-base-200/60 hover:text-base-content"
     ].join(" ");
   }
 
   function panelButtonClasses(id: PanelId): string {
     const isActive = $shellState.activePanel === id;
+    const disabled = !isPanelAllowedInMode(id, $shellState.viewMode);
     return [
-      "btn btn-sm join-item font-medium transition-colors duration-200",
-      isActive ? "btn-secondary shadow" : "btn-ghost text-base-content/70 hover:text-base-content",
-      !isPanelAllowedInMode(id, $shellState.viewMode) ? "btn-disabled opacity-40" : ""
+      "dock-item btn btn-xs sm:btn-sm btn-circle border border-transparent bg-transparent text-base-content/70 transition-all duration-200",
+      isActive
+        ? "btn-secondary text-secondary-content shadow-sm"
+        : "hover:border-base-300 hover:bg-base-200/60 hover:text-base-content",
+      disabled ? "btn-disabled opacity-40" : ""
     ]
       .filter(Boolean)
       .join(" ");
   }
+
+  function nextThemeLabel(): string {
+    return $theme === "light" ? "Switch to dark theme" : "Switch to light theme";
+  }
 </script>
 
-<header class="navbar border-base-300 bg-base-100/95 sticky top-0 z-30 border-b px-4 backdrop-blur">
-  <div class="navbar-start flex-col items-start gap-3 py-3 md:flex-row md:items-center">
-    <div class="flex items-center gap-3">
-      <span class="text-primary text-2xl font-black tracking-tight">Kelpie</span>
-      <span class="badge badge-outline badge-sm">{version}</span>
+<header class="navbar sticky top-0 z-30 border-b border-base-300/70 bg-base-100/95 px-4 backdrop-blur">
+  <div class="navbar-start flex items-center gap-3 py-3">
+    <div class="min-w-[10rem] sm:w-auto">
+      <SaveIndicator />
     </div>
-    <p class="text-base-content/70 text-sm">Markdown to-do studio — edit, preview, and fine-tune your flow.</p>
+    <button
+      type="button"
+      class="btn btn-circle btn-sm border border-base-300/60 bg-base-100/80 text-base-content shadow-sm hover:border-primary/40"
+      on:click={toggleTheme}
+      aria-label={nextThemeLabel()}
+      title={nextThemeLabel()}
+    >
+      {#if $theme === "light"}
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" class="h-4 w-4">
+          <circle cx="12" cy="12" r="4" stroke-width="1.5" />
+          <path
+            stroke-width="1.5"
+            d="M12 2.75v2.5m0 13.5v2.5M4.75 12h-2.5m19.5 0h-2.5M6.3 6.3l-1.77-1.77m14.94 14.94-1.77-1.77m0-11.4 1.77-1.77M6.3 17.7l-1.77 1.77"
+          />
+        </svg>
+      {:else}
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" class="h-4 w-4">
+          <path stroke-width="1.5" d="M19.28 15.56A8 8 0 0 1 8.44 4.72 7.25 7.25 0 1 0 19.28 15.56Z" />
+        </svg>
+      {/if}
+    </button>
   </div>
 
-  <div class="navbar-center flex flex-1 flex-col items-center gap-3 py-3 lg:flex-row lg:justify-center">
-    <div class="join join-horizontal" role="group" aria-label="Panel layout">
+  <div class="navbar-center flex flex-1 items-center justify-center py-3">
+    <div
+      class="tooltip tooltip-bottom"
+      data-tip={`Kelpie ${version}\nMarkdown to-do studio — edit, preview, and fine-tune your flow.`}
+    >
+      <span class="text-xl font-black tracking-tight text-primary sm:text-2xl">Kelpie</span>
+    </div>
+  </div>
+
+  <div class="navbar-end flex items-center gap-3 py-3">
+    <div
+      class="dock items-center gap-1 rounded-full border border-base-300/70 bg-base-100/70 px-1 py-1 shadow-sm"
+      role="group"
+      aria-label="Select workspace mode"
+    >
       {#each viewOptions as option (option.id)}
         <button
           type="button"
-          class={`${viewButtonClasses(option.id)} whitespace-nowrap`}
+          class={viewButtonClasses(option.id)}
           on:click={() => handleViewChange(option.id)}
+          aria-pressed={$shellState.viewMode === option.id}
+          aria-label={option.label}
+          title={option.label}
         >
-          {option.label}
+          {#if option.id === "editor-preview"}
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              class="h-4 w-4"
+            >
+              <rect x="3.5" y="5.5" width="7" height="13" rx="1.5" stroke-width="1.5" />
+              <rect x="13.5" y="5.5" width="7" height="13" rx="1.5" stroke-width="1.5" />
+            </svg>
+          {:else if option.id === "preview-only"}
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              class="h-4 w-4"
+            >
+              <path stroke-width="1.5" d="M3 12s3.5-5.5 9-5.5S21 12 21 12s-3.5 5.5-9 5.5S3 12 3 12Z" />
+              <circle cx="12" cy="12" r="2.5" stroke-width="1.5" />
+            </svg>
+          {:else}
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              class="h-4 w-4"
+            >
+              <circle cx="12" cy="12" r="3" stroke-width="1.5" />
+              <path stroke-width="1.5" d="M4.5 12a7.5 7.5 0 0 1 1.53-4.53L3 4.5l2.5-2.5 3 3A7.5 7.5 0 0 1 12 4.5" />
+              <path
+                stroke-width="1.5"
+                d="M19.5 12a7.5 7.5 0 0 1-1.53 4.53l3.03 3.03-2.5 2.5-3.03-3.03A7.5 7.5 0 0 1 12 19.5"
+              />
+            </svg>
+          {/if}
         </button>
       {/each}
     </div>
 
     {#if $shellState.layout === "mobile"}
-      <div class="join join-horizontal" role="group" aria-label="Active panel">
+      <div
+        class="dock items-center gap-1 rounded-full border border-base-300/70 bg-base-100/70 px-1 py-1 shadow-sm"
+        role="group"
+        aria-label="Select active panel"
+      >
         {#each PANEL_ORDER as panel (panel)}
           <button
             type="button"
-            class={`${panelButtonClasses(panel)} whitespace-nowrap`}
+            class={panelButtonClasses(panel)}
             disabled={!isPanelAllowedInMode(panel, $shellState.viewMode)}
             on:click={() => handlePanelChange(panel)}
+            aria-label={panelLabels[panel]}
+            title={panelLabels[panel]}
+            aria-pressed={$shellState.activePanel === panel}
           >
-            {panelLabels[panel]}
+            {#if panel === "editor"}
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                class="h-3.5 w-3.5"
+              >
+                <path stroke-width="1.5" d="m4.5 15.5 6-6 3 3 6-6" />
+                <path stroke-width="1.5" d="M14.5 5.5h5v5" />
+              </svg>
+            {:else if panel === "preview"}
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                class="h-3.5 w-3.5"
+              >
+                <path stroke-width="1.5" d="M3 12s3.5-5.5 9-5.5S21 12 21 12s-3.5 5.5-9 5.5S3 12 3 12Z" />
+                <circle cx="12" cy="12" r="2.5" stroke-width="1.5" />
+              </svg>
+            {:else}
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                class="h-3.5 w-3.5"
+              >
+                <circle cx="12" cy="12" r="3" stroke-width="1.5" />
+                <path
+                  stroke-width="1.5"
+                  d="M19.5 12a7.5 7.5 0 0 1-1.53 4.53l3.03 3.03-2.5 2.5-3.03-3.03A7.5 7.5 0 0 1 12 19.5"
+                />
+                <path
+                  stroke-width="1.5"
+                  d="M4.5 12a7.5 7.5 0 0 1 1.53-4.53L3 4.5l2.5-2.5 3.03 3.03A7.5 7.5 0 0 1 12 4.5"
+                />
+              </svg>
+            {/if}
           </button>
         {/each}
       </div>
     {/if}
-  </div>
-
-  <div class="navbar-end py-3">
-    <SaveIndicator />
   </div>
 </header>

--- a/apps/web/src/lib/panels/editor/CodeEditorPanel.svelte
+++ b/apps/web/src/lib/panels/editor/CodeEditorPanel.svelte
@@ -35,54 +35,21 @@
   }
 </script>
 
-<section class="editor-panel">
-  <header>
-    <h2>✏️ Markdown Source</h2>
+<section class="flex h-full flex-col bg-base-200/40">
+  <header class="flex items-center justify-between border-b border-base-300/70 px-6 py-5">
+    <div class="tooltip tooltip-bottom" data-tip="Supports Markdown input with GitHub Flavored Markdown extensions.">
+      <h2 class="text-xs font-semibold uppercase tracking-[0.2em] text-base-content/60">Code Editor</h2>
+    </div>
   </header>
-  <textarea
-    aria-label="Markdown editor"
-    bind:value={draft}
-    {placeholder}
-    on:input={handleInput}
-    on:focus={handleFocus}
-    on:blur={handleBlur}
-  ></textarea>
+  <div class="flex flex-1 flex-col px-6 pb-6 pt-4">
+    <textarea
+      aria-label="Markdown editor"
+      bind:value={draft}
+      class="h-full w-full flex-1 resize-none rounded-2xl border border-base-300/70 bg-base-200/80 p-5 font-mono text-sm text-base-content/80 shadow-inner outline-none transition focus:border-primary/40 focus:ring-2 focus:ring-primary/25"
+      {placeholder}
+      on:input={handleInput}
+      on:focus={handleFocus}
+      on:blur={handleBlur}
+    ></textarea>
+  </div>
 </section>
-
-<style>
-  .editor-panel {
-    display: flex;
-    flex-direction: column;
-    flex: 1;
-    padding: 1rem;
-    gap: 0.75rem;
-    background: #f9fafb;
-  }
-
-  header {
-    border-bottom: 1px solid #e5e7eb;
-    padding-bottom: 0.5rem;
-  }
-
-  h2 {
-    margin: 0;
-    font-size: 1rem;
-    font-weight: 600;
-    color: #111827;
-  }
-
-  textarea {
-    flex: 1;
-    resize: none;
-    width: 100%;
-    border: 1px solid #d1d5db;
-    border-radius: 0.5rem;
-    padding: 0.75rem;
-    font-family: var(--editor-font, monospace);
-    font-size: 0.95rem;
-    line-height: 1.5;
-    background: #ffffff;
-    color: #1f2937;
-    box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.04);
-  }
-</style>

--- a/apps/web/src/lib/panels/settings/AppSettingsPanel.svelte
+++ b/apps/web/src/lib/panels/settings/AppSettingsPanel.svelte
@@ -14,89 +14,39 @@
   };
 </script>
 
-<section class="settings-panel">
-  <header>
-    <h2>⚙️ App Settings</h2>
-    <p class="hint">Future work: connect to shell store + DaisyUI themes.</p>
+<section class="flex h-full flex-col bg-base-200/40">
+  <header class="border-b border-base-300/70 px-6 py-5">
+    <h2 class="text-xs font-semibold uppercase tracking-[0.2em] text-base-content/60">App Settings</h2>
+    <p class="mt-2 max-w-xl text-sm text-base-content/60">
+      Future work: connect these controls to the live workspace shell and expose DaisyUI themes.
+    </p>
   </header>
 
-  <div class="form-grid">
-    <fieldset>
-      <label for="debounce">Preview debounce</label>
-      <select id="debounce" disabled>
-        <option value={settings.debounceMs}>{settings.debounceMs}ms</option>
-      </select>
-      <small>Hook up to preview pipeline in a follow-up task.</small>
-    </fieldset>
+  <div class="flex flex-1 flex-col gap-6 overflow-y-auto px-6 pb-6 pt-4">
+    <div class="grid gap-4 sm:grid-cols-2">
+      <fieldset class="flex flex-col gap-2 rounded-2xl border border-dashed border-base-300/70 bg-base-100/80 p-4">
+        <label class="text-sm font-semibold text-base-content" for="debounce">Preview debounce</label>
+        <select
+          id="debounce"
+          class="select select-bordered select-sm rounded-xl border-base-300/70 bg-base-200/70 text-base-content/80"
+          disabled
+        >
+          <option value={settings.debounceMs}>{settings.debounceMs}ms</option>
+        </select>
+        <small class="text-xs text-base-content/60">Hook up to preview pipeline in a follow-up task.</small>
+      </fieldset>
 
-    <fieldset>
-      <label for="theme">Theme</label>
-      <input id="theme" type="text" value={settings.theme} disabled />
-      <small>DaisyUI theme picker to be implemented.</small>
-    </fieldset>
+      <fieldset class="flex flex-col gap-2 rounded-2xl border border-dashed border-base-300/70 bg-base-100/80 p-4">
+        <label class="text-sm font-semibold text-base-content" for="theme">Theme</label>
+        <input
+          id="theme"
+          class="input input-sm input-bordered rounded-xl border-base-300/70 bg-base-200/70 text-base-content/80"
+          type="text"
+          value={settings.theme}
+          disabled
+        />
+        <small class="text-xs text-base-content/60">DaisyUI theme picker to be implemented.</small>
+      </fieldset>
+    </div>
   </div>
 </section>
-
-<style>
-  .settings-panel {
-    padding: 1rem;
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-    background: #f1f5f9;
-    height: 100%;
-  }
-
-  header {
-    border-bottom: 1px solid #cbd5f5;
-    padding-bottom: 0.5rem;
-  }
-
-  h2 {
-    margin: 0;
-    font-size: 1rem;
-    font-weight: 600;
-    color: #0f172a;
-  }
-
-  .hint {
-    margin: 0.25rem 0 0;
-    font-size: 0.85rem;
-    color: #475569;
-  }
-
-  .form-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-    gap: 1rem;
-  }
-
-  fieldset {
-    display: flex;
-    flex-direction: column;
-    gap: 0.35rem;
-    border: 1px dashed #94a3b8;
-    border-radius: 0.75rem;
-    padding: 0.75rem;
-    background: #ffffff;
-  }
-
-  label {
-    font-weight: 600;
-    color: #1e293b;
-  }
-
-  select,
-  input {
-    padding: 0.5rem 0.65rem;
-    border-radius: 0.5rem;
-    border: 1px solid #cbd5e1;
-    background: #f8fafc;
-    color: #334155;
-  }
-
-  small {
-    color: #64748b;
-    font-size: 0.75rem;
-  }
-</style>

--- a/apps/web/src/lib/stores/theme.ts
+++ b/apps/web/src/lib/stores/theme.ts
@@ -1,0 +1,27 @@
+import { browser } from "$app/environment";
+import { writable } from "svelte/store";
+
+export type ThemeName = "light" | "dark";
+
+const STORAGE_KEY = "kelpie-theme";
+
+function getInitialTheme(): ThemeName {
+  if (!browser) return "light";
+  const stored = localStorage.getItem(STORAGE_KEY);
+  return stored === "dark" ? "dark" : "light";
+}
+
+const themeStore = writable<ThemeName>(getInitialTheme());
+
+if (browser) {
+  themeStore.subscribe((value) => {
+    document.documentElement.setAttribute("data-theme", value);
+    localStorage.setItem(STORAGE_KEY, value);
+  });
+}
+
+export const theme = themeStore;
+
+export function toggleTheme(): void {
+  themeStore.update((current) => (current === "light" ? "dark" : "light"));
+}


### PR DESCRIPTION
## Summary
- restyle the workspace toolbar with DaisyUI dock controls, iconography, a left-aligned save indicator, and a dark/light toggle backed by a new theme store
- refresh the shell layout and panel containers with grey, mermaid-inspired surfacing so the editor, preview, and settings views feel cohesive and settings can span the full canvas
- rename and restyle the code editor and task preview panels with tooltips, grey editor chrome, and richer task cards that match the requested look

## Testing
- pnpm --filter web lint *(fails: eslint flags generated `.svelte-kit` type definitions for using `{}` and `any` types)*

------
https://chatgpt.com/codex/tasks/task_e_68d67c208e4483298d2bc9d15139521d