### PR TITLE
Fix deterministic task IDs in markdown parsing

### DIFF
--- a/apps/web/src/lib/parsing/parseTask.test.ts
+++ b/apps/web/src/lib/parsing/parseTask.test.ts
@@ -54,4 +54,17 @@ describe("parseMarkdown", () => {
     expect(tasks[0]?.checked).toBe(false);
     expect(tasks[1]?.checked).toBe(true);
   });
+
+  it("generates deterministic ids for identical input", () => {
+    const line = "- [ ] Repeat";
+    const first = parseTaskLine(line, 3);
+    const second = parseTaskLine(line, 3);
+    expect(first?.id).toBe(second?.id);
+  });
+
+  it("distinguishes duplicate lines by index", () => {
+    const md = `- [ ] Repeat\n- [ ] Repeat`;
+    const tasks = parseMarkdown(md);
+    expect(tasks[0]?.id).not.toBe(tasks[1]?.id);
+  });
 });


### PR DESCRIPTION
## Summary
- replace random task identifiers with a deterministic hash derived from the line content and index
- propagate the line index through markdown parsing so duplicate tasks remain distinguishable
- add unit tests covering deterministic IDs and duplicate line handling

## Testing
- pnpm test:unit

------
https://chatgpt.com/codex/tasks/task_e_68d680df30b88329a0b214d361d58f0f