### PR TITLE
Add save indicator e2e step definitions

### DIFF
--- a/apps/web/e2e/steps/save-indicator.steps.ts
+++ b/apps/web/e2e/steps/save-indicator.steps.ts
@@ -1,0 +1,157 @@
+import { expect, type Page } from "@playwright/test";
+import { createBdd } from "playwright-bdd";
+import type { SaveStatusKind } from "../../src/lib/app-shell/contracts";
+
+const { Given, When, Then } = createBdd();
+
+type SaveStatusUpdate = {
+  kind: SaveStatusKind;
+  message?: string;
+  timestamp?: string | number | null;
+};
+
+const SAVE_INDICATOR_SELECTOR = "[data-kind]";
+
+let currentSaveStatusKind: SaveStatusKind = "idle";
+let lastTimestampIso: string | null = null;
+
+function indicatorLocator(page: Page) {
+  return page.locator(SAVE_INDICATOR_SELECTOR).first();
+}
+
+function badgeLocator(page: Page) {
+  return indicatorLocator(page).locator("span").first();
+}
+
+async function loadAppShell(page: Page): Promise<void> {
+  await page.goto("/");
+  await page.evaluate(() => localStorage.clear());
+  await page.reload();
+  await page.waitForLoadState("networkidle");
+  await expect(indicatorLocator(page)).toBeVisible();
+  currentSaveStatusKind = "idle";
+  lastTimestampIso = null;
+}
+
+async function setSaveStatus(page: Page, update: SaveStatusUpdate): Promise<void> {
+  currentSaveStatusKind = update.kind;
+  await page.evaluate(
+    ([kind, message, timestamp]) => {
+      const setter = (globalThis as { __kelpieSetSaveStatus?: (status: unknown) => void }).__kelpieSetSaveStatus;
+
+      if (typeof setter !== "function") {
+        throw new Error("setSaveStatusForTesting is not available in persistence store");
+      }
+
+      const resolveTimestamp = () => {
+        if (timestamp === null) return null;
+        if (typeof timestamp === "number" && Number.isFinite(timestamp)) {
+          return timestamp;
+        }
+        if (typeof timestamp === "string") {
+          const parsed = Date.parse(timestamp);
+          if (!Number.isNaN(parsed)) {
+            return parsed;
+          }
+        }
+        return Date.now();
+      };
+
+      const baseTimestamp = resolveTimestamp();
+
+      if (kind === "saving") {
+        setter({ kind: "saving", message: message ?? "Saving locally…", timestamp: baseTimestamp ?? Date.now() });
+        return;
+      }
+
+      if (kind === "saved") {
+        setter({ kind: "saved", message: message ?? "Saved locally ✓", timestamp: baseTimestamp ?? Date.now() });
+        return;
+      }
+
+      if (kind === "error") {
+        setter({ kind: "error", message: message ?? "Failed to save locally", timestamp: baseTimestamp ?? Date.now() });
+        return;
+      }
+
+      setter({ kind: "idle", message: message ?? "Saved locally ✓", timestamp: baseTimestamp });
+    },
+    [update.kind, update.message ?? null, update.timestamp ?? null]
+  );
+}
+
+Given("the app shell begins an offline save", async ({ page }) => {
+  await loadAppShell(page);
+});
+
+When("the save status is updated to {string}", async ({ page }, kind: string) => {
+  await setSaveStatus(page, { kind: kind as SaveStatusKind });
+});
+
+Then("the indicator shows {string} with a pulsing badge", async ({ page }, label: string) => {
+  const indicator = indicatorLocator(page);
+  await expect(indicator).toHaveAttribute("data-kind", currentSaveStatusKind);
+  await expect(indicator.getByText(label, { exact: true })).toBeVisible();
+  const badge = badgeLocator(page);
+  await expect(badge).toHaveClass(/badge/);
+  await expect(badge).toHaveClass(/animate-pulse/);
+});
+
+Then("it reports the info tone styling", async ({ page }) => {
+  const indicator = indicatorLocator(page);
+  const badge = badgeLocator(page);
+
+  await expect(indicator).toHaveAttribute("data-kind", "saving");
+
+  const indicatorClasses = await indicator.getAttribute("class");
+  expect(indicatorClasses ?? "").toContain("text-info");
+  expect(indicatorClasses ?? "").toContain("border-info/60");
+  expect(indicatorClasses ?? "").toContain("bg-info/10");
+
+  const badgeClasses = await badge.getAttribute("class");
+  expect(badgeClasses ?? "").toContain("badge-info");
+  expect(badgeClasses ?? "").toContain("animate-pulse");
+});
+
+Given(
+  "the save status is updated to {string} with timestamp {string}",
+  async ({ page }, kind: string, isoTimestamp: string) => {
+    await loadAppShell(page);
+    lastTimestampIso = isoTimestamp;
+    await setSaveStatus(page, { kind: kind as SaveStatusKind, timestamp: isoTimestamp });
+  }
+);
+
+Then("the indicator shows {string}", async ({ page }, label: string) => {
+  const indicator = indicatorLocator(page);
+  await expect(indicator).toHaveAttribute("data-kind", currentSaveStatusKind);
+  await expect(indicator.getByText(label, { exact: true })).toBeVisible();
+});
+
+Then("it displays the formatted time in parentheses after the label", async ({ page }) => {
+  const iso = lastTimestampIso;
+  expect(iso).not.toBeNull();
+
+  const expectedTime = await page.evaluate((timestamp) => new Date(timestamp).toLocaleTimeString(), iso);
+
+  const timestampNode = indicatorLocator(page).locator("span").nth(2);
+  await expect(timestampNode).toHaveText(`(${expectedTime})`);
+});
+
+Given(
+  "the save status is updated to {string} with message {string}",
+  async ({ page }, kind: string, message: string) => {
+    await loadAppShell(page);
+    await setSaveStatus(page, { kind: kind as SaveStatusKind, message });
+  }
+);
+
+Then("the tooltip explains how to retry or export the data", async ({ page }) => {
+  const tooltipMessage =
+    "We couldn't save locally. Retry or export your data to keep a copy while we work on cloud sync.";
+  const tooltip = page.locator("[data-tip]").first();
+  await expect(tooltip).toHaveAttribute("data-tip", tooltipMessage);
+
+  const indicator = indicatorLocator(page);
+  await expect(indicator).toHaveAttribute("title", tooltipMessage);
+});

--- a/apps/web/src/lib/stores/persistence.ts
+++ b/apps/web/src/lib/stores/persistence.ts
@@ -23,3 +23,10 @@ export function markError(error: unknown): void {
 export function resetSaveStatus(): void {
   set(initialStatus);
 }
+
+export function setSaveStatusForTesting(status: SaveStatus): void {
+  set(status);
+}
+
+const globalWithSetter = globalThis as { __kelpieSetSaveStatus?: (status: SaveStatus) => void };
+globalWithSetter.__kelpieSetSaveStatus = setSaveStatusForTesting;


### PR DESCRIPTION
## Summary
- expose a testing-only setter for the save status store to drive the save indicator in end-to-end specs
- add Playwright BDD step definitions that cover saving, saved, and error indicator scenarios

## Testing
- pnpm --filter web test:e2e -- --project=chromium *(fails: Error: Failed to launch: Error: spawn /bin/sh ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68d683f8b10c8329a1f2df9ce63d24a4