### PR TITLE
test(storage): add broadcast sync coverage

### DIFF
--- a/apps/web/e2e/broadcast.test.ts
+++ b/apps/web/e2e/broadcast.test.ts
@@ -1,0 +1,110 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("storage broadcast propagation", () => {
+  test("delivers payloads through BroadcastChannel", async ({ browser }) => {
+    const context = await browser.newContext();
+
+    try {
+      const sender = await context.newPage();
+      const receiver = await context.newPage();
+
+      await sender.goto("/");
+      await receiver.goto("/");
+
+      await sender.evaluate(() => localStorage.clear());
+      await receiver.evaluate(() => localStorage.clear());
+      await sender.reload();
+      await receiver.reload();
+
+      const messagePromise = receiver.evaluate(() => {
+        return new Promise<unknown>((resolve) => {
+          const channel = new BroadcastChannel("kelpie.storage.broadcast");
+          channel.onmessage = (event) => {
+            resolve(event.data);
+            channel.close();
+          };
+        });
+      });
+
+      await sender.evaluate(async () => {
+        const { scheduleBroadcast } = await import("/src/lib/stores/storage/engine.ts");
+        scheduleBroadcast({
+          scope: "settings",
+          updatedAt: "2024-02-01T00:00:00.000Z",
+          origin: "local"
+        });
+        await new Promise((resolve) => setTimeout(resolve, 20));
+      });
+
+      const payload = (await messagePromise) as Record<string, unknown>;
+
+      expect(payload).toMatchObject({
+        scope: "settings",
+        updatedAt: "2024-02-01T00:00:00.000Z",
+        origin: "local"
+      });
+    } finally {
+      await context.close();
+    }
+  });
+
+  test("falls back to storage events when BroadcastChannel is unavailable", async ({ browser }) => {
+    const context = await browser.newContext();
+
+    try {
+      const sender = await context.newPage();
+      await sender.addInitScript(() => {
+        Object.defineProperty(window, "BroadcastChannel", {
+          configurable: true,
+          writable: true,
+          value: undefined
+        });
+      });
+      const receiver = await context.newPage();
+
+      await sender.goto("/");
+      await receiver.goto("/");
+
+      await sender.evaluate(() => localStorage.clear());
+      await receiver.evaluate(() => localStorage.clear());
+      await sender.reload();
+      await receiver.reload();
+
+      const storagePromise = receiver.evaluate(() => {
+        return new Promise<string | null>((resolve) => {
+          window.addEventListener(
+            "storage",
+            (event) => {
+              if (event.key === "kelpie.storage.broadcast") {
+                resolve(event.newValue);
+              }
+            },
+            { once: true }
+          );
+        });
+      });
+
+      await sender.evaluate(async () => {
+        const { scheduleBroadcast } = await import("/src/lib/stores/storage/engine.ts");
+        scheduleBroadcast({
+          scope: "history",
+          updatedAt: "2024-02-02T00:00:00.000Z",
+          origin: "local"
+        });
+        await new Promise((resolve) => setTimeout(resolve, 20));
+      });
+
+      const raw = await storagePromise;
+      expect(raw).toBeTruthy();
+
+      const payload = JSON.parse(raw ?? "{}");
+      expect(payload.scope).toBe("history");
+      expect(payload.updatedAt).toBe("2024-02-02T00:00:00.000Z");
+      expect(payload.origin).toBe("local");
+      expect(payload.__timestamp).toEqual(expect.any(Number));
+      expect(payload.__sequence).toEqual(expect.any(Number));
+    } finally {
+      await context.close();
+    }
+  });
+});

--- a/apps/web/src/lib/stores/storage/broadcast.test.ts
+++ b/apps/web/src/lib/stores/storage/broadcast.test.ts
@@ -1,0 +1,205 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { StorageBroadcast } from "./types";
+
+const sampleBroadcast: StorageBroadcast = {
+  scope: "settings",
+  updatedAt: "2024-01-01T00:00:00.000Z",
+  origin: "local"
+};
+
+function createStorageMock() {
+  return {
+    getItem: vi.fn(),
+    setItem: vi.fn(),
+    removeItem: vi.fn(),
+    clear: vi.fn(),
+    key: vi.fn(),
+    length: 0
+  } satisfies Storage;
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.clearAllTimers();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  vi.resetModules();
+  vi.unstubAllGlobals();
+});
+
+describe("scheduleBroadcast", () => {
+  it("posts messages via BroadcastChannel when available", async () => {
+    vi.useFakeTimers();
+    vi.resetModules();
+
+    const postMessage = vi.fn();
+    const close = vi.fn();
+
+    class FakeBroadcastChannel {
+      name: string;
+
+      constructor(name: string) {
+        this.name = name;
+      }
+
+      postMessage(payload: unknown) {
+        postMessage(payload);
+      }
+
+      close() {
+        close();
+      }
+    }
+
+    const storage = createStorageMock();
+
+    vi.stubGlobal("window", {
+      BroadcastChannel: FakeBroadcastChannel
+    } as unknown as Window & typeof globalThis);
+    vi.stubGlobal("localStorage", storage);
+
+    const { scheduleBroadcast } = await import("./engine");
+
+    scheduleBroadcast(sampleBroadcast);
+    vi.runOnlyPendingTimers();
+
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(postMessage).toHaveBeenCalledWith(sampleBroadcast);
+    expect(storage.setItem).not.toHaveBeenCalled();
+    expect(close).not.toHaveBeenCalled();
+  });
+
+  it("coalesces multiple calls within the same macrotask", async () => {
+    vi.useFakeTimers();
+    vi.resetModules();
+
+    const postMessage = vi.fn();
+
+    class FakeBroadcastChannel {
+      name: string;
+
+      constructor(name: string) {
+        this.name = name;
+      }
+
+      postMessage(payload: unknown) {
+        postMessage(payload);
+      }
+
+      close() {}
+    }
+
+    const storage = createStorageMock();
+
+    vi.stubGlobal("window", {
+      BroadcastChannel: FakeBroadcastChannel
+    } as unknown as Window & typeof globalThis);
+    vi.stubGlobal("localStorage", storage);
+
+    const { scheduleBroadcast } = await import("./engine");
+
+    const first: StorageBroadcast = {
+      scope: "config",
+      updatedAt: "2024-01-02T00:00:00.000Z",
+      origin: "local"
+    };
+
+    const second: StorageBroadcast = {
+      scope: "documents",
+      updatedAt: "2024-01-03T00:00:00.000Z",
+      origin: "external"
+    };
+
+    scheduleBroadcast(first);
+    scheduleBroadcast(second);
+    vi.runOnlyPendingTimers();
+
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(postMessage).toHaveBeenCalledWith(second);
+    expect(storage.setItem).not.toHaveBeenCalled();
+  });
+
+  it("falls back to emitting storage events when BroadcastChannel is unavailable", async () => {
+    vi.useFakeTimers();
+    vi.resetModules();
+
+    const storage = createStorageMock();
+
+    vi.stubGlobal("window", {} as Window & typeof globalThis);
+    vi.stubGlobal("localStorage", storage);
+
+    const { scheduleBroadcast } = await import("./engine");
+
+    scheduleBroadcast(sampleBroadcast);
+    vi.runOnlyPendingTimers();
+
+    expect(storage.setItem).toHaveBeenCalledTimes(1);
+    const [key, raw] = storage.setItem.mock.calls[0]!;
+    expect(key).toBe("kelpie.storage.broadcast");
+
+    const parsed = JSON.parse(raw as string);
+    expect(parsed.scope).toBe(sampleBroadcast.scope);
+    expect(parsed.origin).toBe(sampleBroadcast.origin);
+    expect(parsed.updatedAt).toBe(sampleBroadcast.updatedAt);
+    expect(parsed.__timestamp).toEqual(expect.any(Number));
+    expect(parsed.__sequence).toBe(0);
+  });
+
+  it("recovers from BroadcastChannel failures by falling back to storage events", async () => {
+    vi.useFakeTimers();
+    vi.resetModules();
+
+    const storage = createStorageMock();
+    const postMessageSpy = vi.fn(() => {
+      throw new Error("post failed");
+    });
+    const close = vi.fn();
+
+    class FaultyBroadcastChannel {
+      name: string;
+
+      constructor(name: string) {
+        this.name = name;
+      }
+
+      postMessage(payload: unknown) {
+        postMessageSpy(payload);
+        throw new Error("post failed");
+      }
+
+      close() {
+        close();
+      }
+    }
+
+    vi.stubGlobal("window", {
+      BroadcastChannel: FaultyBroadcastChannel
+    } as unknown as Window & typeof globalThis);
+    vi.stubGlobal("localStorage", storage);
+
+    const { scheduleBroadcast } = await import("./engine");
+
+    scheduleBroadcast(sampleBroadcast);
+    vi.runOnlyPendingTimers();
+
+    expect(postMessageSpy).toHaveBeenCalledTimes(1);
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(storage.setItem).toHaveBeenCalledTimes(1);
+
+    const followUp: StorageBroadcast = {
+      scope: "history",
+      updatedAt: "2024-01-04T00:00:00.000Z",
+      origin: "local"
+    };
+
+    scheduleBroadcast(followUp);
+    vi.runOnlyPendingTimers();
+
+    expect(postMessageSpy).toHaveBeenCalledTimes(1);
+    expect(storage.setItem).toHaveBeenCalledTimes(2);
+    const [, secondRaw] = storage.setItem.mock.calls[1]!;
+    const parsed = JSON.parse(secondRaw as string);
+    expect(parsed.scope).toBe(followUp.scope);
+    expect(parsed.__sequence).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add Vitest coverage for scheduleBroadcast, including channel coalescing and fallbacks
- add Playwright coverage to verify real BroadcastChannel delivery and localStorage fallback paths

## Testing
- pnpm --filter web test:unit -- --run
- pnpm --filter web test:e2e -- --project=chromium *(fails: missing autogenerated BDD step definitions prior to running Playwright)*

------
https://chatgpt.com/codex/tasks/task_e_68d6808d45948329b95106988715bc08