### PR TITLE
Fix GitHub Pages base path for user repos

### DIFF
--- a/apps/web/svelte.config.js
+++ b/apps/web/svelte.config.js
@@ -2,7 +2,8 @@ import adapter from "@sveltejs/adapter-static";
 import { vitePreprocess } from "@sveltejs/vite-plugin-svelte";
 
 const isProd = process.env.NODE_ENV === "production";
-const repo = process.env.GITHUB_REPOSITORY?.split("/")[1] ?? "";
+const [owner = "", repo = ""] = process.env.GITHUB_REPOSITORY?.split("/") ?? [];
+const isUserOrOrgPagesRepo = repo === `${owner}.github.io`;
 
 export default {
   compilerOptions: { runes: true }, // Svelte 5 runes
@@ -10,7 +11,7 @@ export default {
   kit: {
     adapter: adapter(),
     paths: {
-      base: isProd && repo ? `/${repo}` : ""
+      base: isProd && repo && !isUserOrOrgPagesRepo ? `/${repo}` : ""
     },
     prerender: { handleHttpError: "warn" },
     csrf: { trustedOrigins: [] }


### PR DESCRIPTION
## Summary
- avoid setting a subdirectory base path when deploying to user or org GitHub Pages repositories
- keep the existing repo-based path for project pages deployments so asset URLs resolve correctly

## Testing
- pnpm -C apps/web build

------
https://chatgpt.com/codex/tasks/task_e_68d685c1abdc8329870d8da3d16461d1