### PR TITLE
fix: ensure task toggles persist

### DIFF
--- a/apps/web/src/lib/parsing/parseTask.test.ts
+++ b/apps/web/src/lib/parsing/parseTask.test.ts
@@ -3,7 +3,7 @@ import { parseTaskLine, formatTask, parseMarkdown } from "./parseTask";
 
 describe("parseTaskLine", () => {
   it("parses an unchecked task without tags", () => {
-    const t = parseTaskLine("- [ ] Buy milk");
+    const t = parseTaskLine("- [ ] Buy milk", 0);
     expect(t).not.toBeNull();
     expect(t?.checked).toBe(false);
     expect(t?.title).toBe("Buy milk");
@@ -11,34 +11,45 @@ describe("parseTaskLine", () => {
   });
 
   it("parses a checked task", () => {
-    const t = parseTaskLine("- [x] Wash car");
+    const t = parseTaskLine("- [x] Wash car", 5);
     expect(t?.checked).toBe(true);
   });
 
   it("parses @tags correctly", () => {
-    const t = parseTaskLine("- [ ] Do taxes @due(2025-04-15) @priority(A) @estimate(2h)");
+    const t = parseTaskLine("- [ ] Do taxes @due(2025-04-15) @priority(A) @estimate(2h)", 1);
     expect(t?.tags.due).toBe("2025-04-15");
     expect(t?.tags.priority).toBe("A");
     expect(t?.tags.estimate).toBe("2h");
   });
 
   it("parses #hashtags correctly", () => {
-    const t = parseTaskLine("- [ ] Jogging #health #exercise");
+    const t = parseTaskLine("- [ ] Jogging #health #exercise", 2);
     expect(Array.isArray(t?.tags.hashtags)).toBe(true);
     expect(t?.tags.hashtags).toContain("health");
     expect(t?.tags.hashtags).toContain("exercise");
   });
 
   it("ignores non-task lines", () => {
-    const t = parseTaskLine("## Heading");
+    const t = parseTaskLine("## Heading", 3);
     expect(t).toBeNull();
+  });
+
+  it("generates deterministic ids based on line index", () => {
+    const first = parseTaskLine("- [ ] Read book", 4);
+    const second = parseTaskLine("- [x] Read book", 4);
+    const third = parseTaskLine("- [ ] Read book", 5);
+
+    expect(first?.id).toBe("4");
+    expect(second?.id).toBe("4");
+    expect(third?.id).toBe("5");
+    expect(first?.lineIndex).toBe(4);
   });
 });
 
 describe("formatTask", () => {
   it("round-trips a parsed task", () => {
     const line = "- [ ] Buy milk @due(2025-10-31) #groceries";
-    const t = parseTaskLine(line)!;
+    const t = parseTaskLine(line, 7)!;
     const back = formatTask(t);
     expect(back).toContain("Buy milk");
     expect(back).toContain("@due(2025-10-31)");
@@ -53,5 +64,7 @@ describe("parseMarkdown", () => {
     expect(tasks).toHaveLength(2);
     expect(tasks[0]?.checked).toBe(false);
     expect(tasks[1]?.checked).toBe(true);
+    expect(tasks[0]?.lineIndex).toBe(0);
+    expect(tasks[1]?.lineIndex).toBe(1);
   });
 });

--- a/apps/web/src/lib/parsing/parseTask.ts
+++ b/apps/web/src/lib/parsing/parseTask.ts
@@ -4,6 +4,8 @@ export type Task = {
   checked: boolean;
   title: string;
   tags: Record<string, string | string[]>;
+  /** Zero-based position of the line within the source document. */
+  lineIndex: number;
 };
 
 const TAG_RE = /@(\w+)\(([^)]+)\)/g;
@@ -13,12 +15,13 @@ const HASH_RE = /#(\w[\w-]*)/g;
  * Parse a single Markdown line into a Task.
  * Returns null if the line does not match the task pattern.
  */
-export function parseTaskLine(line: string): Task | null {
+export function parseTaskLine(line: string, lineIndex = 0): Task | null {
   const match = /^-\s\[( |x)\]\s(.*)$/.exec(line);
   if (!match) return null;
 
   const checked = match[1] === "x";
-  let rest: string = match[2]!; // ✅ assert non-null
+  const body: string = match[2]!;
+  let rest: string = body; // ✅ assert non-null
 
   const tags: Record<string, string | string[]> = {};
 
@@ -44,11 +47,12 @@ export function parseTaskLine(line: string): Task | null {
   rest = rest.replace(HASH_RE, "");
 
   return {
-    id: crypto.randomUUID(),
+    id: `${lineIndex}`,
     raw: line,
     checked,
     title: rest.trim(),
-    tags
+    tags,
+    lineIndex
   };
 }
 
@@ -74,6 +78,6 @@ export function formatTask(task: Task): string {
 export function parseMarkdown(md: string): Task[] {
   return md
     .split(/\r?\n/)
-    .map((line) => parseTaskLine(line))
+    .map((line, index) => parseTaskLine(line, index))
     .filter((x): x is Task => x !== null);
 }

--- a/apps/web/src/lib/stores/state.toggleTask.test.ts
+++ b/apps/web/src/lib/stores/state.toggleTask.test.ts
@@ -1,0 +1,26 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { get } from "svelte/store";
+
+import { appState, setDocumentContent, tasks, toggleTask } from "./state";
+
+const DOC = `# Heading
+- [ ] Alpha
+some note
+- [x] Beta #tag`;
+
+describe("toggleTask", () => {
+  beforeEach(() => {
+    setDocumentContent(DOC);
+  });
+
+  it("updates the matching line without disturbing surrounding content", () => {
+    const parsed = get(tasks);
+    const beta = parsed.find((task) => task.title === "Beta");
+    expect(beta).toBeDefined();
+
+    toggleTask(beta!.id);
+
+    const updatedFile = get(appState).file.split("\n");
+    expect(updatedFile).toEqual(["# Heading", "- [ ] Alpha", "some note", "- [ ] Beta #tag"]);
+  });
+});

--- a/apps/web/src/lib/stores/state.ts
+++ b/apps/web/src/lib/stores/state.ts
@@ -214,15 +214,20 @@ export function toggleTask(id: string): void {
       return document; // extra guard (strict mode safe)
     }
 
+    if (t.lineIndex < 0 || t.lineIndex >= lines.length) {
+      return document;
+    }
+
     const updated: Task = {
       id: t.id,
       raw: t.raw,
       title: t.title,
       tags: t.tags,
-      checked: !t.checked
+      checked: !t.checked,
+      lineIndex: t.lineIndex
     };
 
-    lines[idx] = formatTask(updated);
+    lines[t.lineIndex] = formatTask(updated);
 
     return { ...document, content: lines.join("\n") };
   });


### PR DESCRIPTION
## Summary
- assign deterministic ids and capture the original line index when parsing tasks
- update `toggleTask` to write back to the correct markdown line and guard invalid indices
- add regression tests for deterministic ids and toggling behavior, and remove the outdated improvement review note

## Testing
- pnpm --filter web test:unit

------
https://chatgpt.com/codex/tasks/task_e_68d67c5943708329b5fe8cef70115b5d