### PR TITLE
Fix Playwright project typing

### DIFF
--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,13 +1,20 @@
 /// <reference types="node" />
 import { defineConfig } from "@playwright/test";
+import type { PlaywrightTestConfig } from "@playwright/test";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { defineBddConfig } from "playwright-bdd";
+
+const webAppDir = resolve(dirname(fileURLToPath(import.meta.url)));
 
 const testDir = defineBddConfig({
   features: "e2e/features/**/*.feature",
   steps: "e2e/steps/**/*.ts"
 });
 
-const availableProjects = [
+type PlaywrightProject = NonNullable<PlaywrightTestConfig["projects"]>[number];
+
+const availableProjects: PlaywrightProject[] = [
   { name: "chromium", use: { browserName: "chromium" } },
   { name: "webkit", use: { browserName: "webkit" } }
   // Firefox intentionally omitted
@@ -35,13 +42,13 @@ export default defineConfig({
     ? {
         command: "pnpm build && pnpm preview",
         port: 4173,
-        cwd: "apps/web" // 👈 force cwd
+        cwd: webAppDir
       }
     : {
         command: "pnpm dev",
         url: "http://localhost:5173",
         reuseExistingServer: true,
-        cwd: "apps/web" // 👈 force cwd
+        cwd: webAppDir
       },
 
   use: {


### PR DESCRIPTION
## Summary
- resolve the Playwright webServer cwd against the config file so spawning pnpm commands works across working directories
- ensure the Playwright project definitions satisfy the typed configuration expectations

## Testing
- pnpm playwright test *(fails: Playwright browsers are not installed in the execution environment)*
- pnpm --filter web check *(fails: existing Svelte module resolution/type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68d686c7262083298fe293c2da3cc965