### PR TITLE
fix: align task toggling and storage broadcasts

### DIFF
--- a/apps/web/src/lib/parsing/parseTask.test.ts
+++ b/apps/web/src/lib/parsing/parseTask.test.ts
@@ -22,6 +22,15 @@ describe("parseTaskLine", () => {
     expect(t?.tags.estimate).toBe("2h");
   });
 
+  it("resets regex state between parses", () => {
+    const line = "- [ ] Do laundry @due(2025-05-01)";
+    const first = parseTaskLine(line);
+    const second = parseTaskLine(line);
+
+    expect(first?.tags.due).toBe("2025-05-01");
+    expect(second?.tags.due).toBe("2025-05-01");
+  });
+
   it("parses #hashtags correctly", () => {
     const t = parseTaskLine("- [ ] Jogging #health #exercise");
     expect(Array.isArray(t?.tags.hashtags)).toBe(true);
@@ -60,11 +69,20 @@ describe("parseMarkdown", () => {
     const first = parseTaskLine(line, 3);
     const second = parseTaskLine(line, 3);
     expect(first?.id).toBe(second?.id);
+    expect(first?.lineIndex).toBe(3);
+    expect(second?.lineIndex).toBe(3);
   });
 
   it("distinguishes duplicate lines by index", () => {
     const md = `- [ ] Repeat\n- [ ] Repeat`;
     const tasks = parseMarkdown(md);
     expect(tasks[0]?.id).not.toBe(tasks[1]?.id);
+  });
+
+  it("preserves the original line index even when non-task lines are present", () => {
+    const md = `# Heading\n\n- [ ] Write tests`;
+    const tasks = parseMarkdown(md);
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0]?.lineIndex).toBe(2);
   });
 });

--- a/apps/web/src/lib/stores/state.ts
+++ b/apps/web/src/lib/stores/state.ts
@@ -214,15 +214,9 @@ export function toggleTask(id: string): void {
       return document; // extra guard (strict mode safe)
     }
 
-    const updated: Task = {
-      id: t.id,
-      raw: t.raw,
-      title: t.title,
-      tags: t.tags,
-      checked: !t.checked
-    };
-
-    lines[idx] = formatTask(updated);
+    const toggled = { ...t, checked: !t.checked } satisfies Task;
+    const updatedLine = formatTask(toggled);
+    lines[t.lineIndex] = updatedLine;
 
     return { ...document, content: lines.join("\n") };
   });

--- a/apps/web/src/lib/stores/storage/engine.test.ts
+++ b/apps/web/src/lib/stores/storage/engine.test.ts
@@ -118,6 +118,7 @@ describe("createStorageEngine", () => {
   });
 
   it("resets storage to defaults and persists the new snapshot", () => {
+    const broadcastSpy = vi.fn();
     const populated = createSnapshot({
       settings: {
         lastActiveDocumentId: "doc-123",
@@ -165,7 +166,7 @@ describe("createStorageEngine", () => {
 
     loadSpy.mockReturnValue(populated);
 
-    const engine = createStorageEngine({ driver });
+    const engine = createStorageEngine({ driver, broadcast: broadcastSpy });
     engine.reset();
 
     expect(saveSpy).toHaveBeenCalledTimes(1);
@@ -182,6 +183,10 @@ describe("createStorageEngine", () => {
 
     expect(get(engine.snapshot)).toEqual(savedSnapshot);
     expect(get(engine.settings)).toEqual(savedSnapshot.settings);
+    expect(broadcastSpy).toHaveBeenCalledTimes(1);
+    expect(broadcastSpy).toHaveBeenCalledWith(expect.objectContaining({ scope: "snapshot", origin: "local" }), {
+      driver
+    });
   });
 
   it("exposes a config store that stays in sync with snapshot updates", () => {
@@ -218,6 +223,7 @@ describe("createStorageEngine", () => {
   });
 
   it("persists updates when the updater returns a new snapshot", () => {
+    const broadcastSpy = vi.fn();
     const baseline = createSnapshot();
     const updated = {
       ...baseline,
@@ -230,7 +236,7 @@ describe("createStorageEngine", () => {
 
     loadSpy.mockReturnValue(baseline);
 
-    const engine = createStorageEngine({ driver });
+    const engine = createStorageEngine({ driver, broadcast: broadcastSpy });
     const changed = engine.update(() => updated);
 
     expect(changed).toBe(true);
@@ -238,6 +244,10 @@ describe("createStorageEngine", () => {
     expect(saveSpy).toHaveBeenCalledWith(updated);
     expect(get(engine.snapshot)).toEqual(updated);
     expect(get(engine.settings)).toEqual(updated.settings);
+    expect(broadcastSpy).toHaveBeenCalledTimes(1);
+    expect(broadcastSpy).toHaveBeenCalledWith(expect.objectContaining({ scope: "snapshot", origin: "local" }), {
+      driver
+    });
   });
 
   it("persists document mutations when returning a new snapshot reference", () => {
@@ -288,16 +298,18 @@ describe("createStorageEngine", () => {
   });
 
   it("does not persist when the updater returns the current snapshot", () => {
+    const broadcastSpy = vi.fn();
     const baseline = createSnapshot();
     loadSpy.mockReturnValue(baseline);
 
-    const engine = createStorageEngine({ driver });
+    const engine = createStorageEngine({ driver, broadcast: broadcastSpy });
     const changed = engine.update((current) => current);
 
     expect(changed).toBe(false);
     expect(saveSpy).not.toHaveBeenCalled();
     expect(get(engine.snapshot)).toEqual(baseline);
     expect(get(engine.settings)).toEqual(baseline.settings);
+    expect(broadcastSpy).not.toHaveBeenCalled();
   });
 
   it("throws when the updater does not return a snapshot", () => {

--- a/docs/improvement-areas.md
+++ b/docs/improvement-areas.md
@@ -1,0 +1,13 @@
+# Recently implemented improvements
+
+## 1. Task toggling keeps the correct source line
+
+`parseTaskLine` now records the original line index for every parsed task, and `toggleTask` uses that metadata when writing back to the Markdown buffer. This ensures toggling a checkbox updates the correct line even when headings or blank lines appear above the task.【F:apps/web/src/lib/parsing/parseTask.ts†L1-L88】【F:apps/web/src/lib/stores/state.ts†L200-L229】 Tests also verify the line index survives documents with intermixed non-task content.【F:apps/web/src/lib/parsing/parseTask.test.ts†L1-L97】
+
+## 2. Regex-based tag parsing resets cursor state
+
+Each invocation of `parseTaskLine` now resets the global regex cursors before and after matching, preventing stale `lastIndex` values from skipping tags on subsequent parses.【F:apps/web/src/lib/parsing/parseTask.ts†L9-L88】 A dedicated test confirms that repeated parses keep extracting the same tag values.【F:apps/web/src/lib/parsing/parseTask.test.ts†L14-L43】
+
+## 3. Storage updates broadcast across tabs
+
+The storage engine now calls `scheduleBroadcast` after resets and any persisted updates, emitting a snapshot-scoped message with the `'local'` origin. This keeps other tabs in sync without manual refreshes.【F:apps/web/src/lib/stores/storage/engine.ts†L1-L191】 Tests assert broadcasts fire only when writes occur and remain silent for no-op updates.【F:apps/web/src/lib/stores/storage/engine.test.ts†L1-L252】


### PR DESCRIPTION
## Summary
- track the original source line for parsed tasks so toggles rewrite the correct markdown line
- reset global regex state between parses and cover the behavior with unit tests
- emit storage broadcasts after resets and persisted updates while allowing tests to inject a stub

## Testing
- pnpm test:unit -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d689a7267c8329886397596a278d9c