### PR TITLE
Implement storage history timelines and undo support

### DIFF
--- a/apps/web/src/lib/stores/storage/engine.test.ts
+++ b/apps/web/src/lib/stores/storage/engine.test.ts
@@ -151,7 +151,9 @@ describe("createStorageEngine", () => {
           scope: "document",
           refId: "doc-123",
           snapshot: {},
-          createdAt: "2024-01-02T00:00:00.000Z"
+          createdAt: "2024-01-02T00:00:00.000Z",
+          origin: "api",
+          sequence: 1
         }
       ],
       audit: [
@@ -387,5 +389,152 @@ describe("createStorageEngine", () => {
 
     expect(saveSpy).toHaveBeenCalledTimes(1);
     expect(get(engine.config)).toEqual(createDefaultConfiguration());
+  });
+
+  it("captures and prunes history entries via the history controller", () => {
+    const baseline = createSnapshot({
+      config: {
+        ...createSnapshot().config,
+        historyEntryCap: 2,
+        historyRetentionDays: 1,
+        debounce: { writeMs: 500, broadcastMs: 200 },
+        auditEntryCap: 20,
+        softDeleteRetentionDays: 7
+      },
+      index: [
+        {
+          id: "doc-123",
+          title: "Doc",
+          createdAt: "2024-01-01T00:00:00.000Z",
+          updatedAt: "2024-01-01T00:00:00.000Z",
+          deletedAt: null,
+          purgeAfter: null
+        }
+      ],
+      documents: {
+        "doc-123": {
+          id: "doc-123",
+          title: "Doc",
+          content: "Hello",
+          createdAt: "2024-01-01T00:00:00.000Z",
+          updatedAt: "2024-01-01T00:00:00.000Z"
+        }
+      },
+      history: [
+        {
+          id: "hist-1",
+          scope: "document",
+          refId: "doc-123",
+          snapshot: { title: "Doc", content: "Hello" },
+          createdAt: "2024-01-01T00:00:00.000Z",
+          origin: "api",
+          sequence: 1
+        }
+      ]
+    });
+
+    loadSpy.mockReturnValue(baseline);
+
+    const engine = createStorageEngine({ driver, now: () => "2024-01-03T00:00:00.000Z" });
+
+    const result = engine.history.capture({
+      scope: "document",
+      refId: "doc-123",
+      snapshot: { title: "Doc", content: "Updated" },
+      origin: "toolbar"
+    });
+
+    expect(result.entry.origin).toBe("toolbar");
+    expect(result.entry.sequence).toBe(2);
+    expect(result.pruned).toHaveLength(1);
+    expect(saveSpy).toHaveBeenCalledTimes(1);
+
+    const snapshot = get(engine.snapshot);
+    expect(snapshot.history).toHaveLength(1);
+    expect(snapshot.history[0]?.origin).toBe("toolbar");
+    expect(snapshot.audit.at(-1)?.type).toBe("history.pruned");
+    expect(engine.history.timeline({ scope: "document", refId: "doc-123" }).cursor?.origin).toBe("toolbar");
+  });
+
+  it("maintains undo/redo stacks across snapshot updates", () => {
+    const baseline = createSnapshot({
+      index: [
+        {
+          id: "doc-123",
+          title: "Doc",
+          createdAt: "2024-01-01T00:00:00.000Z",
+          updatedAt: "2024-01-01T00:00:00.000Z",
+          deletedAt: null,
+          purgeAfter: null
+        }
+      ],
+      documents: {
+        "doc-123": {
+          id: "doc-123",
+          title: "Doc",
+          content: "Current",
+          createdAt: "2024-01-01T00:00:00.000Z",
+          updatedAt: "2024-01-01T00:00:00.000Z"
+        }
+      },
+      history: [
+        {
+          id: "hist-1",
+          scope: "document",
+          refId: "doc-123",
+          snapshot: { title: "Doc", content: "Initial" },
+          createdAt: "2024-01-01T00:00:00.000Z",
+          origin: "api",
+          sequence: 1
+        },
+        {
+          id: "hist-2",
+          scope: "document",
+          refId: "doc-123",
+          snapshot: { title: "Doc", content: "Intermediate" },
+          createdAt: "2024-01-02T00:00:00.000Z",
+          origin: "keyboard",
+          sequence: 2
+        }
+      ]
+    });
+
+    loadSpy.mockReturnValue(baseline);
+
+    const engine = createStorageEngine({ driver, now: () => "2024-01-03T00:00:00.000Z" });
+
+    const undoEntry = engine.history.undo(
+      { scope: "document", refId: "doc-123" },
+      {
+        snapshot: { title: "Doc", content: "Current" },
+        origin: "toolbar"
+      }
+    );
+
+    expect(undoEntry?.id).toBe("hist-2");
+    const timelineAfterUndo = engine.history.timeline({ scope: "document", refId: "doc-123" });
+    expect(timelineAfterUndo.cursor?.id).toBe("hist-1");
+    expect(timelineAfterUndo.future).toHaveLength(1);
+
+    engine.update((snapshot) => {
+      const undoSnapshot = undoEntry?.snapshot as { content: string };
+      return {
+        ...snapshot,
+        documents: {
+          ...snapshot.documents,
+          "doc-123": {
+            ...snapshot.documents["doc-123"],
+            content: undoSnapshot.content
+          }
+        }
+      } satisfies StorageSnapshot;
+    });
+
+    const redoEntry = engine.history.redo({ scope: "document", refId: "doc-123" });
+    expect(redoEntry?.origin).toBe("toolbar");
+
+    const timelineAfterRedo = engine.history.timeline({ scope: "document", refId: "doc-123" });
+    expect(timelineAfterRedo.cursor?.id).toBe("hist-2");
+    expect(timelineAfterRedo.future).toHaveLength(0);
   });
 });

--- a/apps/web/src/lib/stores/storage/history.test.ts
+++ b/apps/web/src/lib/stores/storage/history.test.ts
@@ -1,0 +1,266 @@
+import { describe, expect, it } from "vitest";
+import { captureHistorySnapshot, createHistoryCache, getHistoryTimeline, redoHistory, undoHistory } from "./history";
+import type { HistoryEntry, StorageSnapshot } from "./types";
+
+const BASE_CONFIG = {
+  debounce: { writeMs: 500, broadcastMs: 200 },
+  historyRetentionDays: 7,
+  historyEntryCap: 50,
+  auditEntryCap: 20,
+  softDeleteRetentionDays: 7
+} as const;
+
+const BASE_SETTINGS = {
+  lastActiveDocumentId: "doc-1",
+  panes: {},
+  filters: {},
+  createdAt: "2024-01-01T00:00:00.000Z",
+  updatedAt: "2024-01-01T00:00:00.000Z"
+} as const;
+
+const BASE_INDEX = [
+  {
+    id: "doc-1",
+    title: "Doc",
+    createdAt: "2024-01-01T00:00:00.000Z",
+    updatedAt: "2024-01-01T00:00:00.000Z",
+    deletedAt: null,
+    purgeAfter: null
+  }
+] as const;
+
+const BASE_DOCUMENTS = {
+  "doc-1": {
+    id: "doc-1",
+    title: "Doc",
+    content: "Hello",
+    createdAt: "2024-01-01T00:00:00.000Z",
+    updatedAt: "2024-01-01T00:00:00.000Z"
+  }
+} as const;
+
+function createSnapshot(overrides: Partial<StorageSnapshot> = {}): StorageSnapshot {
+  return {
+    meta: {
+      version: 1,
+      installationId: "test-installation",
+      createdAt: "2024-01-01T00:00:00.000Z",
+      lastOpenedAt: "2024-01-01T00:00:00.000Z",
+      ...(overrides.meta ?? {})
+    },
+    config: { ...BASE_CONFIG, ...(overrides.config ?? {}) },
+    settings: { ...BASE_SETTINGS, ...(overrides.settings ?? {}) },
+    index: overrides.index ?? [...BASE_INDEX],
+    documents: overrides.documents ?? { ...BASE_DOCUMENTS },
+    history: overrides.history ?? [],
+    audit: overrides.audit ?? []
+  } satisfies StorageSnapshot;
+}
+
+describe("history utilities", () => {
+  it("captures history entries with sequential sequence values", () => {
+    const snapshot = createSnapshot();
+
+    const { snapshot: nextSnapshot, entry } = captureHistorySnapshot(
+      snapshot,
+      {
+        scope: "document",
+        refId: "doc-1",
+        snapshot: { title: "Doc", content: "Hello" },
+        origin: "api"
+      },
+      { now: () => "2024-01-02T00:00:00.000Z" }
+    );
+
+    expect(entry.sequence).toBe(1);
+    expect(nextSnapshot.history).toHaveLength(1);
+    expect((nextSnapshot.history[0] as HistoryEntry).origin).toBe("api");
+  });
+
+  it("prunes entries outside the retention window and records an audit entry", () => {
+    const snapshot = createSnapshot({
+      config: {
+        ...BASE_CONFIG,
+        historyRetentionDays: 1,
+        historyEntryCap: 10,
+        debounce: { writeMs: 500, broadcastMs: 200 },
+        auditEntryCap: 20,
+        softDeleteRetentionDays: 7
+      },
+      history: [
+        {
+          id: "hist-old",
+          scope: "document",
+          refId: "doc-1",
+          snapshot: { title: "Doc" },
+          createdAt: "2024-01-01T00:00:00.000Z",
+          origin: "api",
+          sequence: 1
+        }
+      ]
+    });
+
+    const {
+      snapshot: nextSnapshot,
+      pruned,
+      auditEntry
+    } = captureHistorySnapshot(
+      snapshot,
+      {
+        scope: "document",
+        refId: "doc-1",
+        snapshot: { title: "Doc", content: "Hello" },
+        origin: "toolbar"
+      },
+      { now: () => "2024-01-03T00:00:00.000Z" }
+    );
+
+    expect(pruned).toHaveLength(1);
+    expect(nextSnapshot.history).toHaveLength(1);
+    expect(nextSnapshot.history[0]?.origin).toBe("toolbar");
+    expect(auditEntry).not.toBeNull();
+    expect(auditEntry?.type).toBe("history.pruned");
+    expect(auditEntry?.metadata).toMatchObject({ count: 1 });
+  });
+
+  it("enforces the history entry cap", () => {
+    const snapshot = createSnapshot({
+      config: {
+        ...BASE_CONFIG,
+        historyEntryCap: 2,
+        debounce: { writeMs: 500, broadcastMs: 200 },
+        auditEntryCap: 20,
+        softDeleteRetentionDays: 7,
+        historyRetentionDays: 30
+      },
+      history: [
+        {
+          id: "hist-1",
+          scope: "document",
+          refId: "doc-1",
+          snapshot: { title: "Doc" },
+          createdAt: "2024-01-02T00:00:00.000Z",
+          origin: "api",
+          sequence: 1
+        },
+        {
+          id: "hist-2",
+          scope: "document",
+          refId: "doc-1",
+          snapshot: { title: "Doc", content: "Updated" },
+          createdAt: "2024-01-03T00:00:00.000Z",
+          origin: "keyboard",
+          sequence: 2
+        }
+      ]
+    });
+
+    const { snapshot: nextSnapshot, pruned } = captureHistorySnapshot(
+      snapshot,
+      {
+        scope: "document",
+        refId: "doc-1",
+        snapshot: { title: "Doc", content: "Latest" },
+        origin: "toolbar"
+      },
+      { now: () => "2024-01-04T00:00:00.000Z" }
+    );
+
+    expect(nextSnapshot.history).toHaveLength(2);
+    expect(pruned[0]?.id).toBe("hist-1");
+    expect(nextSnapshot.history[0]?.id).toBe("hist-2");
+    expect(nextSnapshot.history[1]?.origin).toBe("toolbar");
+  });
+
+  it("supports undo/redo timelines per document", () => {
+    const snapshot = createSnapshot({
+      history: [
+        {
+          id: "hist-1",
+          scope: "document",
+          refId: "doc-1",
+          snapshot: { title: "Doc", content: "Initial" },
+          createdAt: "2024-01-02T00:00:00.000Z",
+          origin: "api",
+          sequence: 1
+        },
+        {
+          id: "hist-2",
+          scope: "document",
+          refId: "doc-1",
+          snapshot: { title: "Doc", content: "Updated" },
+          createdAt: "2024-01-03T00:00:00.000Z",
+          origin: "keyboard",
+          sequence: 2
+        }
+      ]
+    });
+
+    const cache = createHistoryCache(snapshot);
+    const timelineBefore = getHistoryTimeline(cache, { scope: "document", refId: "doc-1" });
+    expect(timelineBefore.cursor?.id).toBe("hist-2");
+    expect(timelineBefore.past).toHaveLength(1);
+
+    const undoResult = undoHistory(
+      cache,
+      { scope: "document", refId: "doc-1" },
+      {
+        snapshot: { title: "Doc", content: "New" },
+        origin: "toolbar"
+      },
+      { now: () => "2024-01-04T00:00:00.000Z" }
+    );
+
+    expect(undoResult.entry?.id).toBe("hist-2");
+
+    const afterUndo = getHistoryTimeline(cache, { scope: "document", refId: "doc-1" });
+    expect(afterUndo.cursor?.id).toBe("hist-1");
+    expect(afterUndo.future[0]?.origin).toBe("toolbar");
+
+    const redoResult = redoHistory(cache, { scope: "document", refId: "doc-1" });
+    expect(redoResult.entry?.origin).toBe("toolbar");
+
+    const afterRedo = getHistoryTimeline(cache, { scope: "document", refId: "doc-1" });
+    expect(afterRedo.cursor?.id).toBe("hist-2");
+    expect(afterRedo.future).toHaveLength(0);
+    expect(afterRedo.past[0]?.id).toBe("hist-1");
+  });
+
+  it("returns null when undoing without history", () => {
+    const cache = createHistoryCache(createSnapshot());
+    const { entry } = undoHistory(cache, { scope: "document", refId: "doc-1" }, { snapshot: {}, origin: "api" });
+    expect(entry).toBeNull();
+  });
+
+  it("validates history captures for unknown documents", () => {
+    const snapshot = createSnapshot();
+    expect(() =>
+      captureHistorySnapshot(
+        snapshot,
+        {
+          scope: "document",
+          refId: "missing",
+          snapshot: {},
+          origin: "api"
+        },
+        { now: () => "2024-01-02T00:00:00.000Z" }
+      )
+    ).toThrowError("unknown document id 'missing' for history capture");
+  });
+
+  it("validates settings history ref ids", () => {
+    const snapshot = createSnapshot();
+    expect(() =>
+      captureHistorySnapshot(
+        snapshot,
+        {
+          scope: "settings",
+          refId: "doc-1",
+          snapshot: {},
+          origin: "api"
+        },
+        { now: () => "2024-01-02T00:00:00.000Z" }
+      )
+    ).toThrowError("settings history entries must target the 'settings' refId");
+  });
+});

--- a/apps/web/src/lib/stores/storage/history.ts
+++ b/apps/web/src/lib/stores/storage/history.ts
@@ -1,0 +1,338 @@
+import type {
+  AuditEntry,
+  HistoryEntry,
+  HistoryOrigin,
+  HistoryScope,
+  IsoDateTimeString,
+  RuntimeConfiguration,
+  StorageSnapshot
+} from "./types";
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+type HistoryUtilitiesOptions = {
+  now?: () => IsoDateTimeString;
+};
+
+type InternalFutureEntry = {
+  entry: HistoryEntry;
+  cursor: HistoryEntry | null;
+};
+
+type HistoryTimelineState = {
+  scope: HistoryScope;
+  refId: string;
+  past: HistoryEntry[];
+  cursor: HistoryEntry | null;
+  future: InternalFutureEntry[];
+};
+
+export type HistoryTimelineView = {
+  scope: HistoryScope;
+  refId: string;
+  past: HistoryEntry[];
+  cursor: HistoryEntry | null;
+  future: HistoryEntry[];
+};
+
+export type HistoryCache = {
+  timelines: Map<string, HistoryTimelineState>;
+  nextSequence: number;
+};
+
+export type HistoryTarget = {
+  scope: HistoryScope;
+  refId: string;
+};
+
+export type HistoryCaptureInput = {
+  scope: HistoryScope;
+  refId: string;
+  snapshot: unknown;
+  origin: HistoryOrigin;
+  author?: string;
+  createdAt?: IsoDateTimeString;
+  id?: string;
+};
+
+export type HistoryCaptureResult = {
+  snapshot: StorageSnapshot;
+  entry: HistoryEntry;
+  pruned: HistoryEntry[];
+  auditEntry: AuditEntry | null;
+};
+
+export type HistoryUndoContext = {
+  snapshot: unknown;
+  origin: HistoryOrigin;
+  author?: string;
+  createdAt?: IsoDateTimeString;
+  id?: string;
+};
+
+export function createHistoryCache(snapshot: StorageSnapshot): HistoryCache {
+  const cache: HistoryCache = {
+    timelines: new Map<string, HistoryTimelineState>(),
+    nextSequence: 1
+  };
+
+  if (!snapshot.history.length) {
+    return cache;
+  }
+
+  const sorted = [...snapshot.history].sort((a, b) => {
+    if (a.sequence !== b.sequence) {
+      return a.sequence - b.sequence;
+    }
+    return a.createdAt.localeCompare(b.createdAt);
+  });
+
+  for (const entry of sorted) {
+    const timeline = ensureTimeline(cache, { scope: entry.scope, refId: entry.refId });
+    if (timeline.cursor) {
+      timeline.past.push(timeline.cursor);
+    }
+    timeline.cursor = entry;
+    timeline.future = [];
+  }
+
+  const lastSequence = sorted[sorted.length - 1]?.sequence ?? 0;
+  cache.nextSequence = lastSequence + 1;
+
+  return cache;
+}
+
+export function captureHistorySnapshot(
+  snapshot: StorageSnapshot,
+  capture: HistoryCaptureInput,
+  options: HistoryUtilitiesOptions = {}
+): HistoryCaptureResult {
+  validateHistoryCapture(snapshot, capture);
+
+  const nowFn = options.now ?? isoNow;
+  const createdAt = capture.createdAt ?? nowFn();
+  const sequence = computeNextSequence(snapshot.history);
+
+  const entry: HistoryEntry = {
+    id: capture.id ?? createId(),
+    scope: capture.scope,
+    refId: capture.refId,
+    snapshot: capture.snapshot,
+    createdAt,
+    author: capture.author,
+    origin: capture.origin,
+    sequence
+  };
+
+  const nextHistory = [...snapshot.history, entry];
+  const { retained, pruned } = pruneHistory(nextHistory, snapshot.config, nowFn);
+
+  let auditEntry: AuditEntry | null = null;
+  let nextAudit = snapshot.audit;
+
+  if (pruned.length) {
+    auditEntry = createHistoryAuditEntry(pruned, snapshot.config, nowFn);
+    nextAudit = [...snapshot.audit, auditEntry];
+  }
+
+  return {
+    snapshot: {
+      ...snapshot,
+      history: retained,
+      audit: nextAudit
+    },
+    entry,
+    pruned,
+    auditEntry
+  };
+}
+
+export function getHistoryTimeline(cache: HistoryCache, target: HistoryTarget): HistoryTimelineView {
+  const timeline = ensureTimeline(cache, target);
+  return {
+    scope: timeline.scope,
+    refId: timeline.refId,
+    past: [...timeline.past],
+    cursor: timeline.cursor,
+    future: [...timeline.future].reverse().map((item) => item.entry)
+  };
+}
+
+export function undoHistory(
+  cache: HistoryCache,
+  target: HistoryTarget,
+  context: HistoryUndoContext,
+  options: HistoryUtilitiesOptions = {}
+): { entry: HistoryEntry | null; redoEntry: HistoryEntry | null } {
+  const timeline = ensureTimeline(cache, target);
+  if (!timeline.cursor) {
+    return { entry: null, redoEntry: null };
+  }
+
+  const currentCursor = timeline.cursor;
+  const nextCursor = timeline.past.pop() ?? null;
+
+  const nowFn = options.now ?? isoNow;
+  const redoEntry: HistoryEntry = {
+    id: context.id ?? createId(),
+    scope: target.scope,
+    refId: target.refId,
+    snapshot: context.snapshot,
+    createdAt: context.createdAt ?? nowFn(),
+    author: context.author,
+    origin: context.origin,
+    sequence: cache.nextSequence++
+  };
+
+  timeline.future.push({ entry: redoEntry, cursor: currentCursor });
+  timeline.cursor = nextCursor;
+
+  return { entry: currentCursor, redoEntry };
+}
+
+export function redoHistory(cache: HistoryCache, target: HistoryTarget): { entry: HistoryEntry | null } {
+  const timeline = ensureTimeline(cache, target);
+  const futureEntry = timeline.future.pop();
+  if (!futureEntry) {
+    return { entry: null };
+  }
+
+  if (timeline.cursor) {
+    timeline.past.push(timeline.cursor);
+  }
+
+  timeline.cursor = futureEntry.cursor;
+
+  return { entry: futureEntry.entry };
+}
+
+export function pruneCacheEntries(cache: HistoryCache, pruned: HistoryEntry[]): void {
+  if (!pruned.length) {
+    return;
+  }
+
+  const prunedIds = new Set(pruned.map((entry) => entry.id));
+
+  for (const timeline of cache.timelines.values()) {
+    timeline.past = timeline.past.filter((entry) => !prunedIds.has(entry.id));
+    timeline.future = timeline.future.filter(
+      (item) => !prunedIds.has(item.entry.id) && (!item.cursor || !prunedIds.has(item.cursor.id))
+    );
+
+    if (timeline.cursor && prunedIds.has(timeline.cursor.id)) {
+      timeline.cursor = timeline.past.pop() ?? null;
+    }
+  }
+}
+
+function isoNow(): IsoDateTimeString {
+  return new Date().toISOString();
+}
+
+function createId(): string {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID();
+  }
+  return Math.random().toString(36).slice(2);
+}
+
+function computeNextSequence(history: HistoryEntry[]): number {
+  let max = 0;
+  for (const entry of history) {
+    if (typeof entry.sequence === "number" && entry.sequence > max) {
+      max = entry.sequence;
+    }
+  }
+  return max + 1;
+}
+
+function ensureTimeline(cache: HistoryCache, target: HistoryTarget): HistoryTimelineState {
+  const key = `${target.scope}:${target.refId}`;
+  let timeline = cache.timelines.get(key);
+
+  if (!timeline) {
+    timeline = {
+      scope: target.scope,
+      refId: target.refId,
+      past: [],
+      cursor: null,
+      future: []
+    } satisfies HistoryTimelineState;
+    cache.timelines.set(key, timeline);
+  }
+
+  return timeline;
+}
+
+function validateHistoryCapture(snapshot: StorageSnapshot, capture: HistoryCaptureInput): void {
+  if (capture.scope === "settings") {
+    if (capture.refId !== "settings") {
+      throw new Error("settings history entries must target the 'settings' refId");
+    }
+    return;
+  }
+
+  const existsInIndex = snapshot.index.some((entry) => entry.id === capture.refId);
+  const existsInDocuments = capture.refId in snapshot.documents;
+
+  if (!existsInIndex && !existsInDocuments) {
+    throw new Error(`unknown document id '${capture.refId}' for history capture`);
+  }
+}
+
+function pruneHistory(
+  history: HistoryEntry[],
+  config: RuntimeConfiguration,
+  nowFn: () => IsoDateTimeString
+): { retained: HistoryEntry[]; pruned: HistoryEntry[] } {
+  const retentionThreshold =
+    config.historyRetentionDays > 0 ? new Date(nowFn()).getTime() - config.historyRetentionDays * MS_PER_DAY : null;
+  const retained: HistoryEntry[] = [];
+  const pruned: HistoryEntry[] = [];
+
+  for (const entry of history) {
+    const createdAt = Date.parse(entry.createdAt);
+    if (Number.isNaN(createdAt)) {
+      throw new Error(`invalid history timestamp '${entry.createdAt}'`);
+    }
+
+    if (retentionThreshold !== null && createdAt < retentionThreshold) {
+      pruned.push(entry);
+      continue;
+    }
+
+    retained.push(entry);
+  }
+
+  while (retained.length > config.historyEntryCap) {
+    const removed = retained.shift();
+    if (removed) {
+      pruned.push(removed);
+    }
+  }
+
+  return { retained, pruned };
+}
+
+function createHistoryAuditEntry(
+  pruned: HistoryEntry[],
+  config: RuntimeConfiguration,
+  nowFn: () => IsoDateTimeString
+): AuditEntry {
+  return {
+    id: createId(),
+    type: "history.pruned",
+    createdAt: nowFn(),
+    metadata: {
+      count: pruned.length,
+      entryCap: config.historyEntryCap,
+      retentionDays: config.historyRetentionDays,
+      entries: pruned.map((entry) => ({
+        id: entry.id,
+        refId: entry.refId,
+        scope: entry.scope,
+        sequence: entry.sequence
+      }))
+    }
+  } satisfies AuditEntry;
+}

--- a/apps/web/src/lib/stores/storage/index.ts
+++ b/apps/web/src/lib/stores/storage/index.ts
@@ -2,4 +2,5 @@ export * from "./constants";
 export * from "./defaults";
 export * from "./driver";
 export * from "./engine";
+export * from "./history";
 export * from "./types";

--- a/apps/web/src/lib/stores/storage/types.ts
+++ b/apps/web/src/lib/stores/storage/types.ts
@@ -56,6 +56,8 @@ export type DocumentSnapshot = {
 
 export type HistoryScope = "document" | "settings";
 
+export type HistoryOrigin = "keyboard" | "toolbar" | "api";
+
 export type HistoryEntry = {
   id: string;
   scope: HistoryScope;
@@ -63,6 +65,8 @@ export type HistoryEntry = {
   snapshot: unknown; // will be narrowed by feature-specific modules
   createdAt: IsoDateTimeString;
   author?: string;
+  origin: HistoryOrigin;
+  sequence: number;
 };
 
 export type AuditEventType =


### PR DESCRIPTION
## Summary
- add a dedicated history module that captures entries, enforces retention, and maintains undo/redo timelines
- extend the storage engine to expose history helpers and keep caches in sync with snapshot updates
- expand storage tests to cover history capture, pruning, and undo/redo flows

## Testing
- pnpm --filter web test:unit -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d6889d6dd48329a66bd2a4f335861e