### PR TITLE
test: add coverage for storage driver helper

### DIFF
--- a/apps/web/src/lib/stores/storage/driver.test.ts
+++ b/apps/web/src/lib/stores/storage/driver.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createLocalStorageDriver } from "./driver";
+import type { StorageSnapshot } from "./types";
+
+const STORAGE_KEY = "kelpie:test-driver";
+
+const SAMPLE_SNAPSHOT: StorageSnapshot = {
+  meta: {
+    version: 1,
+    installationId: "install-123",
+    createdAt: "2024-01-01T00:00:00.000Z",
+    lastOpenedAt: "2024-01-02T00:00:00.000Z"
+  },
+  config: {
+    debounce: { writeMs: 250, broadcastMs: 100 },
+    historyRetentionDays: 14,
+    historyEntryCap: 50,
+    auditEntryCap: 25,
+    softDeleteRetentionDays: 7
+  },
+  settings: {
+    lastActiveDocumentId: null,
+    panes: {},
+    filters: {},
+    createdAt: "2024-01-01T00:00:00.000Z",
+    updatedAt: "2024-01-01T00:00:00.000Z"
+  },
+  index: [],
+  documents: {},
+  history: [],
+  audit: []
+};
+
+describe("createLocalStorageDriver", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    if ("localStorage" in globalThis && globalThis.localStorage) {
+      globalThis.localStorage.clear();
+    }
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    if ("localStorage" in globalThis && globalThis.localStorage) {
+      globalThis.localStorage.clear();
+    }
+  });
+
+  it("loads and parses snapshots from localStorage", () => {
+    const driver = createLocalStorageDriver(STORAGE_KEY);
+    globalThis.localStorage.setItem(STORAGE_KEY, JSON.stringify(SAMPLE_SNAPSHOT));
+
+    expect(driver.load()).toEqual(SAMPLE_SNAPSHOT);
+  });
+
+  it("returns null when the stored payload cannot be parsed", () => {
+    const driver = createLocalStorageDriver(STORAGE_KEY);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    globalThis.localStorage.setItem(STORAGE_KEY, "not-json");
+
+    expect(driver.load()).toBeNull();
+    expect(warnSpy).toHaveBeenCalledWith("Kelpie storage: failed to parse snapshot", expect.any(SyntaxError));
+  });
+
+  it("no-ops when localStorage is unavailable", () => {
+    vi.stubGlobal("localStorage", undefined);
+    const driver = createLocalStorageDriver(STORAGE_KEY);
+
+    expect(driver.load()).toBeNull();
+
+    expect(() => driver.save(SAMPLE_SNAPSHOT)).not.toThrow();
+    expect(() => driver.clear()).not.toThrow();
+  });
+
+  it("subscribes to storage events and filters by key", () => {
+    const driver = createLocalStorageDriver(STORAGE_KEY);
+    const callback = vi.fn();
+    const addEventListener = vi.spyOn(window, "addEventListener");
+    const removeEventListener = vi.spyOn(window, "removeEventListener");
+
+    const unsubscribe = driver.subscribe(callback);
+
+    expect(addEventListener).toHaveBeenCalledWith("storage", expect.any(Function));
+    const handler = addEventListener.mock.calls[0][1] as (event: StorageEvent) => void;
+
+    handler(new StorageEvent("storage", { key: "other" }));
+    expect(callback).not.toHaveBeenCalled();
+
+    handler(new StorageEvent("storage", { key: STORAGE_KEY }));
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+    expect(removeEventListener).toHaveBeenCalledWith("storage", handler);
+  });
+
+  it("returns a noop unsubscribe when window is unavailable", () => {
+    const originalWindow = globalThis.window;
+    vi.stubGlobal("window", undefined);
+    const driver = createLocalStorageDriver(STORAGE_KEY);
+    const callback = vi.fn();
+
+    const unsubscribe = driver.subscribe(callback);
+
+    expect(() => unsubscribe()).not.toThrow();
+    expect(callback).not.toHaveBeenCalled();
+
+    if (originalWindow) {
+      vi.stubGlobal("window", originalWindow);
+    }
+  });
+});

--- a/docs/testing-gaps.md
+++ b/docs/testing-gaps.md
@@ -1,0 +1,32 @@
+# Testing Coverage Gaps
+
+This document lists notable areas of the Kelpie codebase that currently lack automated test coverage or rely on minimal assertions. Strengthening tests in these areas will help catch regressions as the spec evolves.
+
+## App shell layout and responsiveness
+
+- `AppShell.svelte` derives `showEditor`, `showPreview`, and `showSettings` flags from the shell store and wires a `startLayoutWatcher` cleanup path, but there are no component tests ensuring the correct panel visibility across desktop vs. mobile layouts or that the layout watcher unsubscribes on destroy.【F:apps/web/src/lib/app-shell/AppShell.svelte†L1-L79】
+- The shell store exposes `startLayoutWatcher`, which binds a `matchMedia` listener. The existing store tests cover layout and panel setters but never exercise this watcher hook or its cleanup behaviour.【F:apps/web/src/lib/stores/shell.ts†L1-L57】【F:apps/web/src/lib/stores/shell.test.ts†L1-L33】
+
+## Toolbar interactions
+
+- `Toolbar.svelte` contains event handlers for switching view modes, activating panels on mobile, and toggling the theme, along with helper functions that compute button classes and accessibility labels. None of these pathways are verified in unit tests, so regressions to mode switching or theming logic would go unnoticed.【F:apps/web/src/lib/app-shell/Toolbar.svelte†L1-L205】
+
+## Panel components
+
+- `CodeEditorPanel.svelte` dispatches `contentChange` and `editingState` events when the textarea updates or focus changes, but there are no tests confirming that drafts sync when external `value` props change or that events fire with the expected payloads.【F:apps/web/src/lib/panels/editor/CodeEditorPanel.svelte†L1-L51】
+- `InteractivePreviewPanel.svelte` formats tags, derives due labels, and emits `toggleTask` events per task. Tests are absent for these helpers and for ensuring the DOM reflects completed states, hashtags, and other metadata from parsed tasks.【F:apps/web/src/lib/panels/preview/InteractivePreviewPanel.svelte†L1-L97】
+- `AppSettingsPanel.svelte` currently renders disabled controls seeded from props. Even basic snapshot or interaction tests are missing, so any future wiring risks regressions once the panel becomes interactive.【F:apps/web/src/lib/panels/settings/AppSettingsPanel.svelte†L1-L44】
+
+## Storage primitives
+
+- The default snapshot builders—`createDefaultConfiguration`, `createDefaultSettings`, and `createInitialSnapshot`—generate timestamps, schema versions, and installation IDs, yet there are no targeted tests asserting these contracts or guarding against regressions in seeded values.【F:apps/web/src/lib/stores/storage/defaults.ts†L1-L55】
+
+## Spec extraction tooling
+
+- The spec DSL extractor script reads Markdown specs and writes `.feature` files, but it currently runs without any automated verification. Adding tests (or converting it into a library function) would protect against regressions in regex parsing or output paths.【F:apps/web/src/lib/specdsl/extract.js†L1-L45】
+
+## End-to-end scenarios
+
+- Existing Playwright suites only cover task persistence and storage broadcast fallbacks. Critical flows—such as switching layout modes, toggling tasks from the preview, or validating toolbar controls—remain untested end-to-end.【F:apps/web/e2e/demo.test.ts†L1-L25】【F:apps/web/e2e/broadcast.test.ts†L1-L69】
+
+Addressing these gaps with focused unit tests, component tests (via `@testing-library/svelte`), and additional Playwright journeys will improve confidence as new features land.


### PR DESCRIPTION
## Summary
- add Vitest coverage for createLocalStorageDriver, covering parse failures, missing storage APIs, and subscription cleanup
- update the testing gap report to remove the driver coverage TODO now that tests exist

## Testing
- pnpm --filter web exec vitest run src/lib/stores/storage/driver.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d68ff7b1248329837d1ca7dd3ad9fe