### PR TITLE
Fix SaveIndicator unit tests

### DIFF
--- a/apps/web/src/lib/app-shell/SaveIndicator.svelte
+++ b/apps/web/src/lib/app-shell/SaveIndicator.svelte
@@ -5,7 +5,8 @@
 
   $: status = $saveStatus;
   $: statusLabel = status.message;
-  $: timestampLabel = status.timestamp ? new Date(status.timestamp).toLocaleTimeString() : undefined;
+  $: timestampLabel =
+    status.timestamp && status.kind === "saved" ? `(${new Date(status.timestamp).toLocaleTimeString()})` : undefined;
   const localSaveTooltip =
     "Changes are stored locally on this device for now. Cloud sync will be introduced in a future release.";
   const errorTooltip =
@@ -53,8 +54,13 @@
     aria-label={`${statusLabel}. ${tooltipMessage}`}
     tabindex="0"
   >
-    <span class={`font-semibold uppercase tracking-[0.15em] ${tone.label}`}>{statusLabel}</span>
-    {#if timestampLabel && status.kind === "saved"}
+    <div class="flex items-center gap-2">
+      {#if status.kind === "saving"}
+        <span class="badge badge-xs animate-pulse border border-info/40 bg-info/20 text-info/90">&nbsp;</span>
+      {/if}
+      <span class={`font-semibold uppercase tracking-[0.15em] ${tone.label}`}>{statusLabel}</span>
+    </div>
+    {#if timestampLabel}
       <span class={`text-[0.65rem] ${tone.timestamp}`}>{timestampLabel}</span>
     {/if}
   </div>


### PR DESCRIPTION
## Summary
- render a pulsing badge in the SaveIndicator while saving to match the persistence spec
- wrap the saved timestamp in parentheses so the indicator output aligns with expectations

## Testing
- pnpm --filter web test:unit -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d692f196088329aa55caa82fec2254