### PR TITLE
Broaden task parser whitespace tolerance and refresh spec

### DIFF
--- a/apps/web/src/lib/parsing/parseTask.test.ts
+++ b/apps/web/src/lib/parsing/parseTask.test.ts
@@ -15,6 +15,38 @@ describe("parseTaskLine", () => {
     expect(t?.checked).toBe(true);
   });
 
+  it("parses tasks without space inside the brackets", () => {
+    const unchecked = parseTaskLine("- []Empty");
+    const checked = parseTaskLine("- [x]Done");
+
+    expect(unchecked?.checked).toBe(false);
+    expect(checked?.checked).toBe(true);
+  });
+
+  it("parses tasks with extra whitespace inside the brackets", () => {
+    const paddedUnchecked = parseTaskLine("- [    ] Extra space");
+    const paddedChecked = parseTaskLine("- [  X  ] Extra space checked");
+
+    expect(paddedUnchecked?.checked).toBe(false);
+    expect(paddedChecked?.checked).toBe(true);
+  });
+
+  it("parses uppercase checkbox markers", () => {
+    const t = parseTaskLine("- [X] Ship release");
+    expect(t?.checked).toBe(true);
+  });
+
+  it("parses alternative bullet markers and indentation", () => {
+    const star = parseTaskLine("* [ ] Star bullet");
+    const plus = parseTaskLine("+ [X] Plus bullet");
+    const indented = parseTaskLine("    - [ ] Indented");
+
+    expect(star?.title).toBe("Star bullet");
+    expect(star?.checked).toBe(false);
+    expect(plus?.checked).toBe(true);
+    expect(indented?.title).toBe("Indented");
+  });
+
   it("parses @tags correctly", () => {
     const t = parseTaskLine("- [ ] Do taxes @due(2025-04-15) @priority(A) @estimate(2h)");
     expect(t?.tags.due).toBe("2025-04-15");

--- a/apps/web/src/lib/parsing/parseTask.ts
+++ b/apps/web/src/lib/parsing/parseTask.ts
@@ -23,10 +23,11 @@ function resetLastIndex(re: RegExp): void {
  * Returns null if the line does not match the task pattern.
  */
 export function parseTaskLine(line: string, index = 0): Task | null {
-  const match = /^-\s\[( |x)\]\s(.*)$/.exec(line);
+  const match = /^\s*[-*+]\s*\[(\s*[xX]?\s*)\]\s*(.*)$/.exec(line);
   if (!match) return null;
 
-  const checked = match[1] === "x";
+  const marker = match[1] ?? "";
+  const checked = marker.trim().toLowerCase() === "x";
   let rest: string = match[2]!; // ✅ assert non-null
 
   const tags: Record<string, string | string[]> = {};

--- a/specs/task-parser.spec.md
+++ b/specs/task-parser.spec.md
@@ -1,0 +1,87 @@
+# Task Parser Spec
+
+## 1. Introduction
+
+The **Task Parser** turns Markdown checklist lines into structured `Task` records that power the editor, preview, and storage
+layers. Parsing must be permissive enough to reflect user-authored Markdown while still emitting a canonical representation that
+other subsystems can rely on.
+
+## 2. Outcomes
+
+- **For users**
+  - Markdown written in their editor of choice is recognised as tasks even when checkbox spacing or bullet markers vary.
+  - Parsed tasks are normalised back to a consistent `- [ ]` / `- [x]` format before rendering, so documents stay tidy.
+  - Common metadata tags (`@due`, `@repeat`, etc.) always round-trip without being lost.
+- **For developers**
+  - Have a predictable contract for how task lines are tokenised, including the complete list of first-class tags.
+  - Extend parsing rules without breaking downstream consumers by relying on the canonical formatter.
+  - Confidently add future behaviour such as nested subtasks with clear depth limits.
+
+## 3. Current Behaviour
+
+- A task line matches optional indentation, a bullet marker (`-`, `*`, or `+`), optional whitespace, and a checkbox with any
+  combination of spaces and a single `x`/`X` inside (e.g., `- []`, `* [ x ]`, `+ [    X    ]`).
+- The parser trims the text after the checkbox into the task `title` while preserving `@tag(value)` tokens and `#hashtags` for
+  later extraction.
+- `formatTask` always emits canonical Markdown of the form `- [ ] Task` or `- [x] Task` regardless of the input spacing or
+  bullet style, keeping stored content consistent.
+- Each parsed task receives a deterministic hash-based `id` scoped by the original line text and zero-based line index.
+
+## 4. Supported Metadata & Tags
+
+The parser treats `@tag(value)` pairs generically, but the product currently relies on the following first-class tags. These must
+continue to parse into the `tags` record and round-trip through `formatTask`:
+
+| Tag              | Purpose              | Example                             |
+| ---------------- | -------------------- | ----------------------------------- |
+| `@done(...)`     | Completion timestamp | `- [x] Close loop @done(...)`       |
+| `@due(...)`      | Due date             | `- [ ] File taxes @due(2025-04-15)` |
+| `@repeat(...)`   | Recurrence cadence   | `- [ ] Weekly review @repeat(1w)`   |
+| `@priority(...)` | Priority flag        | `- [ ] Draft brief @priority(A)`    |
+| `@estimate(...)` | Effort estimate      | `- [ ] QA pass @estimate(2h)`       |
+
+Additionally, plain `#hashtags` are collected into the `hashtags` array on the `tags` object.
+
+## 5. Known Limitations
+
+1. **Nested subtasks** – Indentation is ignored beyond matching a single task line, so hierarchical relationships are lost.
+2. **Escaped characters** – Tag values cannot include `)` or escaped characters, limiting expressive metadata.
+3. **Duplicate tags** – Re-using the same tag key overwrites the previous value (except for `hashtags`).
+
+## 6. Goals
+
+- Keep checkbox parsing flexible (accept multiple bullet markers, indentation, and varied whitespace inside `[]`) while
+  normalising output via `formatTask`.
+- Preserve and expose all recognised tags, ensuring that future features can rely on consistent metadata.
+- Provide clear extension points for richer metadata parsing without introducing a heavy Markdown dependency.
+- Document and plan for nested subtasks so future work can introduce up to **five** levels of nesting.
+
+## 7. Non-Goals (MVP)
+
+- Introducing a full Markdown AST parser.
+- Supporting arbitrary inline formatting (tables, block quotes) inside task titles beyond plain text and metadata tokens.
+- Rewriting historical documents to infer nesting automatically.
+
+## 8. Behaviour Details
+
+- **Checkbox detection** – Regex tolerates indentation, bullet variants, and whitespace around the marker. Trimmed `x`/`X`
+  indicates a checked task; empty or whitespace-only markers remain unchecked.
+- **Tag extraction** – The parser iterates over `@tag(value)` entries, storing the last occurrence per key. `#hashtags` are
+  collected after tag removal and exposed as `tags.hashtags` (string array).
+- **Formatting** – Before persisting or rendering, call `formatTask` on parsed tasks to normalise checkbox spacing and bullet
+  style to `- [ ]` / `- [x]`. This step also appends tags and hashtags in a consistent order.
+- **Document parsing** – `parseMarkdown` splits documents by newline, preserving the zero-based `lineIndex` for each task.
+
+## 9. Future Work
+
+- Support up to **five** levels of nested tasks by pairing indentation depth with parent relationships.
+- Allow escaped characters in tag values (e.g., `@note(contains \) parenthesis)`), potentially by switching to a tokenizer.
+- Represent multi-valued tags without overwriting, likely via arrays or structured metadata objects.
+
+## 15. AI Handoff & Test Tracking
+
+- **Implemented:** Baseline permissive checkbox parsing, canonical formatter, tag and hashtag extraction.
+- **Pending:** Nested task hierarchy (depth up to five), escaped tag characters, multi-value tag support.
+- **Test coverage targets:**
+  - Unit: `apps/web/src/lib/parsing/parseTask.test.ts`
+  - Integration: Covered indirectly via preview/editor specs once nesting work begins.


### PR DESCRIPTION
## Summary
- allow the checkbox parser to accept markers padded with arbitrary whitespace inside the brackets
- cover padded checkbox markers with targeted unit tests
- rewrite the task parser spec to document supported tags, normalization, and the plan for five-level nesting

## Testing
- pnpm --filter web exec vitest run src/lib/parsing/parseTask.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d692487a208329a18ce5882fd61486