### PR TITLE
Add markdown view toggle to preview panel

### DIFF
--- a/apps/web/src/lib/panels/preview/InteractivePreviewPanel.svelte
+++ b/apps/web/src/lib/panels/preview/InteractivePreviewPanel.svelte
@@ -3,10 +3,23 @@
 <script lang="ts">
   import { createEventDispatcher } from "svelte";
   import type { Task } from "$lib/parsing/parseTask";
+  import { renderMarkdown } from "$lib/utils/renderMarkdown";
 
   const dispatch = createEventDispatcher<{ toggleTask: { id: string } }>();
 
   export let tasks: Task[] = [];
+  export let content = "";
+
+  type ViewMode = "tasks" | "markdown";
+  let view: ViewMode = "tasks";
+
+  const tabs: Array<{ id: ViewMode; label: string; description: string }> = [
+    { id: "tasks", label: "Tasks", description: "View parsed tasks" },
+    { id: "markdown", label: "Document", description: "View rendered Markdown" }
+  ];
+
+  $: markdownHtml = renderMarkdown(content);
+  $: trimmedContent = content.trim();
 
   function handleToggle(id: string) {
     dispatch("toggleTask", { id });
@@ -36,101 +49,135 @@
 </script>
 
 <section class="flex h-full flex-col bg-base-200/40">
-  <header class="flex items-center justify-between border-b border-base-300/70 px-6 py-5">
-    <h2 class="text-xs font-semibold uppercase tracking-[0.2em] text-base-content/60">Tasks</h2>
+  <header class="flex flex-wrap items-center justify-between gap-3 border-b border-base-300/70 px-6 py-5">
+    <h2 class="text-xs font-semibold uppercase tracking-[0.2em] text-base-content/60">Preview</h2>
+    <nav aria-label="Preview mode" class="flex items-center gap-1 rounded-full bg-base-300/50 p-1">
+      {#each tabs as tab (tab.id)}
+        <button
+          type="button"
+          class={`rounded-full px-3 py-1 text-[0.7rem] font-semibold uppercase tracking-wide transition focus:outline-none focus-visible:ring-2 focus-visible:ring-primary ${
+            view === tab.id ? "bg-base-100 text-base-content shadow" : "text-base-content/60 hover:text-base-content"
+          }`}
+          aria-pressed={view === tab.id}
+          on:click={() => (view = tab.id)}
+          aria-label={tab.description}
+        >
+          {tab.label}
+        </button>
+      {/each}
+    </nav>
   </header>
 
-  {#if tasks.length === 0}
+  {#if view === "tasks"}
+    {#if tasks.length === 0}
+      <div class="flex flex-1 items-center justify-center px-6">
+        <p
+          class="rounded-full border border-dashed border-base-300/80 bg-base-100/80 px-6 py-3 text-sm text-base-content/60"
+        >
+          No tasks parsed yet — start typing in the editor to see them here.
+        </p>
+      </div>
+    {:else}
+      <ul class="flex flex-1 flex-col gap-3 overflow-y-auto px-6 pb-6 pt-4">
+        {#each tasks as task (task.id)}
+          {@const dueLabel = getDueLabel(task)}
+          {@const hashtags = getHashtags(task)}
+          {@const otherTags = getOtherTags(task)}
+          <li
+            class="rounded-2xl border border-base-300/70 bg-base-100/70 p-3 shadow-sm transition hover:border-primary/40 hover:bg-base-100"
+            data-completed={task.checked}
+          >
+            <label class="group flex items-start gap-4">
+              <span class="relative mt-1 flex h-5 w-5 items-center justify-center">
+                <input
+                  class="peer absolute inset-0 h-5 w-5 cursor-pointer appearance-none rounded-full"
+                  type="checkbox"
+                  checked={task.checked}
+                  on:change={() => handleToggle(task.id)}
+                  aria-label={`Toggle ${task.title}`}
+                />
+                <span
+                  class="pointer-events-none absolute inset-0 rounded-full border-2 border-base-content/30 bg-base-200/80 transition-all duration-200 peer-checked:border-primary peer-checked:bg-primary/90"
+                ></span>
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  class="pointer-events-none relative hidden h-3 w-3 text-base-100 peer-checked:block"
+                >
+                  <path stroke-width="2" d="m5 13 4 4L19 7" />
+                </svg>
+              </span>
+
+              <div class="flex flex-1 flex-col gap-2">
+                <div class="flex flex-wrap items-start justify-between gap-3">
+                  <p
+                    class={`text-base font-semibold leading-snug transition ${
+                      task.checked ? "text-base-content/50 line-through" : "text-base-content"
+                    }`}
+                  >
+                    {task.title}
+                  </p>
+                  {#if hashtags.length > 0}
+                    <div class="flex flex-wrap justify-end gap-2">
+                      {#each hashtags as tag (tag)}
+                        <span
+                          class="badge badge-sm border-0 bg-base-300/70 text-[0.65rem] font-semibold uppercase tracking-wide text-base-content/70"
+                        >
+                          #{tag}
+                        </span>
+                      {/each}
+                    </div>
+                  {/if}
+                </div>
+
+                <div class="flex flex-wrap items-center gap-2 text-xs text-base-content/70 sm:text-sm">
+                  {#if dueLabel}
+                    <span class="badge badge-sm border-0 bg-success/20 text-success-content/90">
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        class="mr-1 h-3 w-3"
+                      >
+                        <circle cx="12" cy="12" r="7" stroke-width="1.5" />
+                        <path stroke-width="1.5" d="M12 8v4l2.5 1.5" />
+                      </svg>
+                      {dueLabel}
+                    </span>
+                  {/if}
+
+                  {#each otherTags as [key, value] (key)}
+                    <span class="badge badge-sm border border-base-300/70 bg-base-100/70 text-base-content/70">
+                      <span class="font-semibold capitalize">{key}</span>
+                      <span class="ml-1 text-base-content/60">{value}</span>
+                    </span>
+                  {/each}
+                </div>
+              </div>
+            </label>
+          </li>
+        {/each}
+      </ul>
+    {/if}
+  {:else if trimmedContent.length === 0}
     <div class="flex flex-1 items-center justify-center px-6">
       <p
         class="rounded-full border border-dashed border-base-300/80 bg-base-100/80 px-6 py-3 text-sm text-base-content/60"
       >
-        No tasks parsed yet — start typing in the editor to see them here.
+        Nothing to preview yet — start typing in the editor to render the document.
       </p>
     </div>
   {:else}
-    <ul class="flex flex-1 flex-col gap-3 overflow-y-auto px-6 pb-6 pt-4">
-      {#each tasks as task (task.id)}
-        {@const dueLabel = getDueLabel(task)}
-        {@const hashtags = getHashtags(task)}
-        {@const otherTags = getOtherTags(task)}
-        <li
-          class="rounded-2xl border border-base-300/70 bg-base-100/70 p-3 shadow-sm transition hover:border-primary/40 hover:bg-base-100"
-          data-completed={task.checked}
-        >
-          <label class="group flex items-start gap-4">
-            <span class="relative mt-1 flex h-5 w-5 items-center justify-center">
-              <input
-                class="peer absolute inset-0 h-5 w-5 cursor-pointer appearance-none rounded-full"
-                type="checkbox"
-                checked={task.checked}
-                on:change={() => handleToggle(task.id)}
-                aria-label={`Toggle ${task.title}`}
-              />
-              <span
-                class="pointer-events-none absolute inset-0 rounded-full border-2 border-base-content/30 bg-base-200/80 transition-all duration-200 peer-checked:border-primary peer-checked:bg-primary/90"
-              ></span>
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                class="pointer-events-none relative hidden h-3 w-3 text-base-100 peer-checked:block"
-              >
-                <path stroke-width="2" d="m5 13 4 4L19 7" />
-              </svg>
-            </span>
-
-            <div class="flex flex-1 flex-col gap-2">
-              <div class="flex flex-wrap items-start justify-between gap-3">
-                <p
-                  class={`text-base font-semibold leading-snug transition ${
-                    task.checked ? "text-base-content/50 line-through" : "text-base-content"
-                  }`}
-                >
-                  {task.title}
-                </p>
-                {#if hashtags.length > 0}
-                  <div class="flex flex-wrap justify-end gap-2">
-                    {#each hashtags as tag (tag)}
-                      <span
-                        class="badge badge-sm border-0 bg-base-300/70 text-[0.65rem] font-semibold uppercase tracking-wide text-base-content/70"
-                      >
-                        #{tag}
-                      </span>
-                    {/each}
-                  </div>
-                {/if}
-              </div>
-
-              <div class="flex flex-wrap items-center gap-2 text-xs text-base-content/70 sm:text-sm">
-                {#if dueLabel}
-                  <span class="badge badge-sm border-0 bg-success/20 text-success-content/90">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      stroke="currentColor"
-                      class="mr-1 h-3 w-3"
-                    >
-                      <circle cx="12" cy="12" r="7" stroke-width="1.5" />
-                      <path stroke-width="1.5" d="M12 8v4l2.5 1.5" />
-                    </svg>
-                    {dueLabel}
-                  </span>
-                {/if}
-
-                {#each otherTags as [key, value] (key)}
-                  <span class="badge badge-sm border border-base-300/70 bg-base-100/70 text-base-content/70">
-                    <span class="font-semibold capitalize">{key}</span>
-                    <span class="ml-1 text-base-content/60">{value}</span>
-                  </span>
-                {/each}
-              </div>
-            </div>
-          </label>
-        </li>
-      {/each}
-    </ul>
+    <div class="flex flex-1 flex-col overflow-hidden">
+      <div class="flex-1 overflow-y-auto px-6 pb-6 pt-4">
+        <article class="prose prose-sm max-w-none text-base-content/80 dark:prose-invert">
+          <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+          {@html markdownHtml}
+        </article>
+      </div>
+    </div>
   {/if}
 </section>

--- a/apps/web/src/lib/utils/renderMarkdown.ts
+++ b/apps/web/src/lib/utils/renderMarkdown.ts
@@ -1,0 +1,233 @@
+const PLACEHOLDER_SUFFIX = "\u0000";
+const CODE_PLACEHOLDER_PREFIX = `${PLACEHOLDER_SUFFIX}CODE`;
+const IMAGE_PLACEHOLDER_PREFIX = `${PLACEHOLDER_SUFFIX}IMG`;
+const LINK_PLACEHOLDER_PREFIX = `${PLACEHOLDER_SUFFIX}LNK`;
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function escapeAttribute(value: string): string {
+  return escapeHtml(value).replace(/`/g, "&#96;");
+}
+
+function renderInline(text: string): string {
+  const codeTokens: string[] = [];
+  let working = text.replace(/`([^`]+)`/g, (_, code: string) => {
+    const index = codeTokens.length;
+    codeTokens.push(`<code>${escapeHtml(code)}</code>`);
+    return `${CODE_PLACEHOLDER_PREFIX}${index}${PLACEHOLDER_SUFFIX}`;
+  });
+
+  const imageTokens: string[] = [];
+  working = working.replace(/!\[([^\]]*)\]\(([^)]+)\)/g, (_, alt: string, src: string) => {
+    const index = imageTokens.length;
+    imageTokens.push(`<img src="${escapeAttribute(src)}" alt="${escapeHtml(alt)}" loading="lazy" decoding="async" />`);
+    return `${IMAGE_PLACEHOLDER_PREFIX}${index}${PLACEHOLDER_SUFFIX}`;
+  });
+
+  const linkTokens: Array<{ label: string; href: string }> = [];
+  working = working.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_, label: string, href: string) => {
+    const index = linkTokens.length;
+    linkTokens.push({ label, href });
+    return `${LINK_PLACEHOLDER_PREFIX}${index}${PLACEHOLDER_SUFFIX}`;
+  });
+
+  let escaped = escapeHtml(working);
+
+  escaped = escaped.replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>");
+  escaped = escaped.replace(/__(.+?)__/g, "<strong>$1</strong>");
+  escaped = escaped.replace(/~~(.+?)~~/g, "<del>$1</del>");
+  escaped = escaped.replace(/(^|[^*])\*(?!\s)([^*]+?)(?<!\s)\*(?!\*)/g, "$1<em>$2</em>");
+  escaped = escaped.replace(/(^|[^_])_(?!\s)([^_]+?)(?<!\s)_(?!_)/g, "$1<em>$2</em>");
+
+  const linkPattern = new RegExp(`${LINK_PLACEHOLDER_PREFIX}(\\d+)${PLACEHOLDER_SUFFIX}`, "g");
+  escaped = escaped.replace(linkPattern, (_, rawIndex: string) => {
+    const index = Number(rawIndex);
+    const token = linkTokens[index];
+    if (!token) return "";
+    const labelHtml = renderInline(token.label);
+    const href = escapeAttribute(token.href);
+    return `<a href="${href}" target="_blank" rel="noreferrer noopener">${labelHtml}</a>`;
+  });
+
+  const imagePattern = new RegExp(`${IMAGE_PLACEHOLDER_PREFIX}(\\d+)${PLACEHOLDER_SUFFIX}`, "g");
+  escaped = escaped.replace(imagePattern, (_, rawIndex: string) => {
+    const index = Number(rawIndex);
+    return imageTokens[index] ?? "";
+  });
+
+  const codePattern = new RegExp(`${CODE_PLACEHOLDER_PREFIX}(\\d+)${PLACEHOLDER_SUFFIX}`, "g");
+  escaped = escaped.replace(codePattern, (_, rawIndex: string) => {
+    const index = Number(rawIndex);
+    return codeTokens[index] ?? "";
+  });
+
+  return escaped;
+}
+
+function finalizeParagraph(html: string[], paragraphOpen: boolean): boolean {
+  if (paragraphOpen) {
+    html.push("</p>");
+    return false;
+  }
+  return paragraphOpen;
+}
+
+export function renderMarkdown(markdown: string): string {
+  const lines = markdown.replace(/\r\n?/g, "\n").split("\n");
+  const html: string[] = [];
+
+  let paragraphOpen = false;
+  let listType: "ul" | "ol" | null = null;
+  let blockquoteOpen = false;
+  let inCodeBlock = false;
+  let codeLanguage = "";
+  const codeBuffer: string[] = [];
+
+  const closeParagraph = () => {
+    paragraphOpen = finalizeParagraph(html, paragraphOpen);
+  };
+
+  const closeList = () => {
+    if (listType) {
+      html.push(`</${listType}>`);
+      listType = null;
+    }
+  };
+
+  const closeBlockquote = () => {
+    if (blockquoteOpen) {
+      closeParagraph();
+      closeList();
+      html.push("</blockquote>");
+      blockquoteOpen = false;
+    }
+  };
+
+  const flushCodeBlock = () => {
+    const codeContent = codeBuffer.join("\n");
+    const langClass = codeLanguage ? ` class="language-${escapeAttribute(codeLanguage)}"` : "";
+    html.push(`<pre><code${langClass}>${escapeHtml(codeContent)}</code></pre>`);
+    codeBuffer.length = 0;
+    codeLanguage = "";
+  };
+
+  for (const rawLine of lines) {
+    const trimmed = rawLine.trim();
+
+    if (inCodeBlock) {
+      if (trimmed.startsWith("```") || trimmed.startsWith("~~~")) {
+        flushCodeBlock();
+        inCodeBlock = false;
+        continue;
+      }
+      codeBuffer.push(rawLine);
+      continue;
+    }
+
+    if (trimmed.startsWith("```") || trimmed.startsWith("~~~")) {
+      closeParagraph();
+      closeList();
+      inCodeBlock = true;
+      codeLanguage = trimmed.slice(3).trim();
+      if (codeLanguage.startsWith("`") || codeLanguage.startsWith("~")) {
+        codeLanguage = codeLanguage.replace(/^[`~]+/, "");
+      }
+      continue;
+    }
+
+    if (trimmed === "") {
+      closeParagraph();
+      closeList();
+      closeBlockquote();
+      continue;
+    }
+
+    let workingLine = rawLine;
+    if (trimmed.startsWith(">")) {
+      if (!blockquoteOpen) {
+        closeParagraph();
+        closeList();
+        html.push("<blockquote>");
+        blockquoteOpen = true;
+      }
+      workingLine = workingLine.replace(/^\s*>\s?/, "");
+    } else if (blockquoteOpen) {
+      closeBlockquote();
+      workingLine = rawLine;
+    }
+
+    const workingTrimmed = workingLine.trim();
+
+    if (/^(-{3,}|_{3,}|\*{3,})$/.test(workingTrimmed)) {
+      closeParagraph();
+      closeList();
+      html.push("<hr />");
+      continue;
+    }
+
+    const headingMatch = workingTrimmed.match(/^(#{1,6})\s+(.*)$/);
+    if (headingMatch) {
+      closeParagraph();
+      closeList();
+      const [, hashes = "", headingTitle = ""] = headingMatch;
+      const level = Math.min(Math.max(hashes.length, 1), 6);
+      html.push(`<h${level}>${renderInline(headingTitle)}</h${level}>`);
+      continue;
+    }
+
+    const listMatch = workingTrimmed.match(/^(\d+\.|[-*+])\s+(.*)$/);
+    if (listMatch) {
+      const [, bullet = "", rawContent = ""] = listMatch;
+      const type = /^\d+\.$/.test(bullet) ? "ol" : "ul";
+      if (listType !== type) {
+        closeParagraph();
+        closeList();
+        html.push(`<${type}>`);
+        listType = type;
+      }
+      const content = rawContent ?? "";
+      const taskMatch = type === "ul" ? content.match(/^\[( |x|X)\]\s+(.*)$/) : null;
+      if (taskMatch) {
+        const [, marker = " ", taskLabel = ""] = taskMatch;
+        const checked = marker.trim().toLowerCase() === "x";
+        const label = renderInline(taskLabel);
+        html.push(
+          `<li><label class="inline-flex items-start gap-2 align-top"><input type="checkbox" disabled ${checked ? "checked" : ""} /><span>${label}</span></label></li>`
+        );
+      } else {
+        html.push(`<li>${renderInline(content)}</li>`);
+      }
+      continue;
+    }
+
+    if (listType) {
+      closeList();
+    }
+
+    if (!paragraphOpen) {
+      html.push("<p>");
+      paragraphOpen = true;
+    } else {
+      html.push("<br />");
+    }
+
+    html.push(renderInline(workingTrimmed));
+  }
+
+  if (inCodeBlock) {
+    flushCodeBlock();
+  }
+
+  closeParagraph();
+  closeList();
+  closeBlockquote();
+
+  return html.join("\n");
+}

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -22,7 +22,7 @@
   </svelte:fragment>
 
   <svelte:fragment slot="preview">
-    <InteractivePreviewPanel tasks={$tasks} on:toggleTask={handleToggle} />
+    <InteractivePreviewPanel tasks={$tasks} content={$appState.file} on:toggleTask={handleToggle} />
   </svelte:fragment>
 
   <svelte:fragment slot="settings">


### PR DESCRIPTION
## Summary
- add a preview toolbar that switches between parsed tasks and a rendered document view
- render the markdown content inside the preview panel by passing the current file content into the component
- implement a small markdown renderer that outputs sanitized HTML for the document preview

## Testing
- pnpm --filter web check *(fails: existing type errors in storage and settings modules)*

------
https://chatgpt.com/codex/tasks/task_e_68d699556394832983796041213b3669