### PR TITLE
Fix save indicator tooltip locator in tests

### DIFF
--- a/apps/web/e2e/steps/save-indicator.steps.ts
+++ b/apps/web/e2e/steps/save-indicator.steps.ts
@@ -23,6 +23,10 @@ function badgeLocator(page: Page) {
   return indicatorLocator(page).locator("span").first();
 }
 
+function tooltipLocator(page: Page) {
+  return indicatorLocator(page).locator("xpath=ancestor-or-self::*[@data-tip]").first();
+}
+
 async function loadAppShell(page: Page): Promise<void> {
   await page.goto("/");
   await page.evaluate(() => localStorage.clear());
@@ -149,7 +153,7 @@ Given(
 Then("the tooltip explains how to retry or export the data", async ({ page }) => {
   const tooltipMessage =
     "We couldn't save locally. Retry or export your data to keep a copy while we work on cloud sync.";
-  const tooltip = page.locator("[data-tip]").first();
+  const tooltip = tooltipLocator(page);
   await expect(tooltip).toHaveAttribute("data-tip", tooltipMessage);
 
   const indicator = indicatorLocator(page);


### PR DESCRIPTION
## Summary
- scope the save indicator tooltip lookup to the indicator element to handle multiple tooltips

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6e6a08e208329abb632ab1ca9c76f