### PR TITLE
Show saved timestamp in SaveIndicator

### DIFF
--- a/apps/web/src/lib/app-shell/SaveIndicator.svelte
+++ b/apps/web/src/lib/app-shell/SaveIndicator.svelte
@@ -6,14 +6,15 @@
   $: status = $saveStatus;
   $: statusLabel = status.message;
   $: lastSavedAt = status.timestamp && status.kind === "saved" ? new Date(status.timestamp) : undefined;
+  $: formattedTimestamp = lastSavedAt?.toLocaleTimeString();
   const localSaveTooltip =
     "Changes are stored locally on this device for now. Cloud sync will be introduced in a future release.";
   const errorTooltip =
     "We couldn't save locally. Retry or export your data to keep a copy while we work on cloud sync.";
   $: tooltipMessage = (() => {
     const base = status.kind === "error" ? errorTooltip : localSaveTooltip;
-    if (lastSavedAt) {
-      return `${base}\nLast saved at ${lastSavedAt.toLocaleTimeString()}.`;
+    if (formattedTimestamp) {
+      return `${base}\nLast saved at ${formattedTimestamp}.`;
     }
     return base;
   })();
@@ -57,10 +58,16 @@
     tabindex="0"
   >
     <div class="flex items-center gap-2">
-      {#if status.kind === "saving"}
-        <span class="badge badge-xs animate-pulse border border-info/40 bg-info/20 text-info/90">&nbsp;</span>
-      {/if}
+      <span
+        class="badge badge-xs border border-info/40 bg-info/20 text-info/90"
+        class:hidden={status.kind !== "saving"}
+        class:animate-pulse={status.kind === "saving"}
+        aria-hidden="true">&nbsp;</span
+      >
       <span class={`text-sm font-medium tracking-tight ${tone.label}`}>{statusLabel}</span>
+      {#if formattedTimestamp}
+        <span class="text-xs text-base-content/60">({formattedTimestamp})</span>
+      {/if}
     </div>
   </div>
 </div>

--- a/apps/web/src/lib/app-shell/SaveIndicator.test.ts
+++ b/apps/web/src/lib/app-shell/SaveIndicator.test.ts
@@ -51,8 +51,8 @@ describe("SaveIndicator", () => {
 
     const indicator = screen.getByLabelText(/Saved locally/);
     expect(indicator).toHaveAttribute("data-kind", "saved");
-    const timestamp = within(indicator).getByText(/\d{1,2}:\d{2}/);
-    expect(timestamp.textContent).toContain(":");
+    const timestamp = within(indicator).getByText(/\(.+:.+\)/);
+    expect(timestamp.textContent).toMatch(/^\(.+\)$/);
   });
 
   it("surfaces errors with retry tooltip", async () => {


### PR DESCRIPTION
## Summary
- display the last saved time beside the SaveIndicator label when a timestamp is available
- update the tooltip and unit test expectations to cover the new timestamp formatting

## Testing
- pnpm --filter web test:unit -- --run SaveIndicator

------
https://chatgpt.com/codex/tasks/task_e_68d6e6c455d48329aa81ba5c7376a767