### PR TITLE
Refine save indicator structure and styling

### DIFF
--- a/apps/web/src/lib/app-shell/SaveIndicator.svelte
+++ b/apps/web/src/lib/app-shell/SaveIndicator.svelte
@@ -1,73 +1,92 @@
 <svelte:options runes={false} />
 
 <script lang="ts">
+  import SaveIndicatorIcon from "./SaveIndicatorIcon.svelte";
   import { saveStatus } from "$lib/stores/persistence";
+  import type { SaveStatus } from "$lib/app-shell/contracts";
 
-  $: status = $saveStatus;
-  $: statusLabel = status.message;
-  $: lastSavedAt = status.timestamp && status.kind === "saved" ? new Date(status.timestamp) : undefined;
-  $: formattedTimestamp = lastSavedAt?.toLocaleTimeString();
   const localSaveTooltip =
     "Changes are stored locally on this device for now. Cloud sync will be introduced in a future release.";
   const errorTooltip =
     "We couldn't save locally. Retry or export your data to keep a copy while we work on cloud sync.";
-  $: tooltipMessage = (() => {
-    const base = status.kind === "error" ? errorTooltip : localSaveTooltip;
-    if (formattedTimestamp) {
-      return `${base}\nLast saved at ${formattedTimestamp}.`;
-    }
-    return base;
-  })();
 
-  type ToneClasses = { container: string; label: string };
+  type ToneClasses = { badge: string; icon: string };
 
-  $: tone = (() => {
-    const base: ToneClasses = {
-      container: "border-success/60 bg-success/10 text-success/90",
-      label: "text-success"
-    };
-    if (status.kind === "error") {
-      return {
-        container: "border-error/60 bg-error/10 text-error/90",
-        label: "text-error"
-      } satisfies ToneClasses;
+  const toneByKind: Record<SaveStatus["kind"], ToneClasses> = {
+    idle: {
+      badge: "border-success/40 bg-success/10 text-success",
+      icon: "text-success"
+    },
+    saving: {
+      badge: "border-info/40 bg-info/10 text-info",
+      icon: "text-info"
+    },
+    saved: {
+      badge: "border-success/40 bg-success/10 text-success",
+      icon: "text-success"
+    },
+    error: {
+      badge: "border-error/40 bg-error/10 text-error",
+      icon: "text-error"
     }
-    if (status.kind === "saving") {
-      return {
-        container: "border-info/60 bg-info/10 text-info/90 animate-pulse",
-        label: "text-info"
-      } satisfies ToneClasses;
-    }
-    return base;
-  })();
+  };
 
-  $: containerClasses = [
-    "flex flex-col gap-1 rounded-2xl border px-3 py-2 text-xs shadow-sm backdrop-blur transition-all duration-300",
-    tone.container
-  ].join(" ");
+  const tooltipByKind: Record<SaveStatus["kind"], string> = {
+    idle: localSaveTooltip,
+    saving: localSaveTooltip,
+    saved: localSaveTooltip,
+    error: errorTooltip
+  };
+
+  $: status = $saveStatus;
+  $: statusLabel = status.message;
+  $: tone = toneByKind[status.kind] ?? toneByKind.saved;
+  $: lastSavedAt = status.timestamp && status.kind === "saved" ? new Date(status.timestamp) : undefined;
+  $: formattedTimestamp = lastSavedAt?.toLocaleTimeString();
+  $: tooltipBase = tooltipByKind[status.kind] ?? localSaveTooltip;
+  $: tooltipMessage = formattedTimestamp ? `${tooltipBase}\nLast saved at ${formattedTimestamp}.` : tooltipBase;
+  $: badgeClasses = ["indicator", tone.badge, status.kind === "saving" ? "indicator--saving animate-pulse" : ""]
+    .filter(Boolean)
+    .join(" ");
 </script>
 
-<div class="tooltip tooltip-bottom w-full md:w-auto" data-tip={tooltipMessage}>
+<div class="indicator-tooltip tooltip tooltip-bottom" data-tip={tooltipMessage}>
   <!-- svelte-ignore a11y-no-noninteractive-tabindex -->
-  <div
-    class={containerClasses}
+  <span
+    class={badgeClasses}
     data-kind={status.kind}
     aria-live="polite"
+    role="status"
     title={tooltipMessage}
     aria-label={`${statusLabel}. ${tooltipMessage}`}
     tabindex="0"
   >
-    <div class="flex items-center gap-2">
-      <span
-        class="badge badge-xs border border-info/40 bg-info/20 text-info/90"
-        class:hidden={status.kind !== "saving"}
-        class:animate-pulse={status.kind === "saving"}
-        aria-hidden="true">&nbsp;</span
-      >
-      <span class={`text-sm font-medium tracking-tight ${tone.label}`}>{statusLabel}</span>
-      {#if formattedTimestamp}
-        <span class="text-xs text-base-content/60">({formattedTimestamp})</span>
-      {/if}
-    </div>
-  </div>
+    <SaveIndicatorIcon kind={status.kind} toneClass={tone.icon} />
+    <span class="indicator__label">{statusLabel}</span>
+    {#if formattedTimestamp}
+      <span class="indicator__timestamp">({formattedTimestamp})</span>
+    {/if}
+  </span>
 </div>
+
+<style lang="postcss">
+  .indicator-tooltip {
+    @apply w-full md:w-auto;
+  }
+
+  .indicator {
+    @apply badge badge-lg w-full justify-start gap-2 border px-3 py-3 text-left text-sm font-medium shadow-sm transition-all duration-300 md:w-auto;
+  }
+
+  .indicator--saving {
+    @apply animate-pulse;
+  }
+
+  .indicator__label {
+    @apply leading-tight;
+  }
+
+  .indicator__timestamp {
+    @apply text-xs text-base-content/60;
+  }
+</style>

--- a/apps/web/src/lib/app-shell/SaveIndicatorIcon.svelte
+++ b/apps/web/src/lib/app-shell/SaveIndicatorIcon.svelte
@@ -1,0 +1,66 @@
+<svelte:options runes={false} />
+
+<script lang="ts">
+  import type { SaveStatus } from "$lib/app-shell/contracts";
+
+  export let kind: SaveStatus["kind"];
+  export let toneClass: string;
+
+  $: iconClasses = ["indicator__icon", toneClass, kind === "saving" ? "indicator__icon--saving" : ""]
+    .filter(Boolean)
+    .join(" ");
+</script>
+
+{#if kind === "error"}
+  <svg
+    class={iconClasses}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="1.5"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+  >
+    <path d="M12 3.75 4.5 20.25h15L12 3.75Z"></path>
+    <path d="M12 10.5v4.5"></path>
+    <path d="M12 17.25h.008"></path>
+  </svg>
+{:else if kind === "saving"}
+  <svg
+    class={iconClasses}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="1.5"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+  >
+    <circle class="opacity-20" cx="12" cy="12" r="8.5"></circle>
+    <path d="M12 3.5a8.5 8.5 0 0 1 8.5 8.5" class="opacity-90"></path>
+  </svg>
+{:else}
+  <svg
+    class={iconClasses}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="1.5"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+  >
+    <path d="m5.5 12.75 3.75 3.75 9-9"></path>
+  </svg>
+{/if}
+
+<style lang="postcss">
+  .indicator__icon {
+    @apply size-4 shrink-0;
+  }
+
+  .indicator__icon--saving {
+    @apply animate-spin;
+  }
+</style>


### PR DESCRIPTION
## Summary
- extract a dedicated `SaveIndicatorIcon` component to remove repeated SVG markup
- centralize tone and tooltip configuration while moving badge styling into a PostCSS block
- retain timestamp rendering and accessibility metadata for the save indicator badge

## Testing
- pnpm --filter web exec vitest --run src/lib/app-shell/SaveIndicator.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d6ed41698c8329a3dbc0fc7f5687b9