### PR TITLE
Fix view mode selectors and layout detection

### DIFF
--- a/apps/web/src/lib/app-shell/ViewModeToggleButton.svelte
+++ b/apps/web/src/lib/app-shell/ViewModeToggleButton.svelte
@@ -34,6 +34,7 @@
       aria-pressed={$shellState.viewMode === option.id}
       aria-label={option.label}
       title={option.label}
+      data-testid={`view-mode-${option.id}`}
     >
       {#if option.id === "editor-preview"}
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" class="h-5 w-5">

--- a/apps/web/src/lib/stores/shell.ts
+++ b/apps/web/src/lib/stores/shell.ts
@@ -22,7 +22,7 @@ export const shellState = readable<ShellState>(initialState, (set) => {
 });
 
 export function setLayout(layout: ShellLayout): void {
-  const normalized: ShellLayout = layout === "mobile" ? "desktop" : layout;
+  const normalized: ShellLayout = layout === "mobile" ? "mobile" : "desktop";
   shellStateStore.update((state) => {
     if (state.layout === normalized) return state;
     return { ...state, layout: normalized } satisfies ShellState;


### PR DESCRIPTION
## Summary
- add deterministic test identifiers to the view mode toggle buttons for the E2E suite
- ensure the shell layout store preserves the mobile layout when responsive changes occur

## Testing
- pnpm --filter web test:e2e *(fails: Playwright browsers are not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d6f1124b6c83299eae70a1cc930f94