### PR TITLE
Use data test ids in preview E2E tests

### DIFF
--- a/apps/web/e2e/demo.test.ts
+++ b/apps/web/e2e/demo.test.ts
@@ -8,24 +8,24 @@ test.describe("task persistence", () => {
   });
 
   test("toggled tasks remain checked after reloading the app", async ({ page }) => {
-    const tasks = page.locator(".task-item");
+    const tasks = page.getByTestId("task-card");
     await expect(tasks).toHaveCount(2);
 
     const firstTask = tasks.first();
     await expect(firstTask).toContainText("Buy milk");
 
-    const firstCheckbox = firstTask.getByRole("checkbox");
+    const firstCheckbox = firstTask.getByTestId("task-checkbox");
     await firstCheckbox.check();
     await expect(firstCheckbox).toBeChecked();
-    await expect(firstTask).toHaveClass(/done/);
+    await expect(firstTask).toHaveAttribute("data-completed", "true");
 
     await page.reload();
 
-    const tasksAfterReload = page.locator(".task-item");
+    const tasksAfterReload = page.getByTestId("task-card");
     await expect(tasksAfterReload).toHaveCount(2);
 
     const firstAfterReload = tasksAfterReload.first();
-    await expect(firstAfterReload).toHaveClass(/done/);
-    await expect(firstAfterReload.getByRole("checkbox")).toBeChecked();
+    await expect(firstAfterReload).toHaveAttribute("data-completed", "true");
+    await expect(firstAfterReload.getByTestId("task-checkbox")).toBeChecked();
   });
 });

--- a/apps/web/e2e/interactive-preview.test.ts
+++ b/apps/web/e2e/interactive-preview.test.ts
@@ -34,17 +34,13 @@ test.describe("interactive preview", () => {
   test("renders metadata badges for parsed tasks", async ({ page }) => {
     await loadDocument(page, "- [ ] Plan trip @due(2025-12-24) #travel #planning");
 
-    const taskCard = page
-      .locator("li", {
-        has: page.getByRole("checkbox", { name: "Toggle Plan trip" })
-      })
-      .first();
+    const taskCard = page.getByTestId("task-card").first();
 
     await expect(taskCard).toBeVisible();
     await expect(taskCard).toHaveAttribute("data-completed", "false");
-    await expect(taskCard.getByText("2025-12-24", { exact: true })).toBeVisible();
-    await expect(taskCard.getByText("#travel", { exact: true })).toBeVisible();
-    await expect(taskCard.getByText("#planning", { exact: true })).toBeVisible();
+    await expect(taskCard.getByTestId("task-due")).toHaveText(/2025-12-24/);
+    await expect(taskCard.getByTestId("task-hashtag").filter({ hasText: "#travel" })).toBeVisible();
+    await expect(taskCard.getByTestId("task-hashtag").filter({ hasText: "#planning" })).toBeVisible();
   });
 
   test("updates preview when editing the markdown document", async ({ page }) => {
@@ -55,22 +51,18 @@ test.describe("interactive preview", () => {
     const appendedLine = "\n- [ ] Capture inspiration @due(2025-08-15) #inbox";
     await editor.fill(`${original}${appendedLine}`);
 
-    const newTaskCard = page.locator("li", {
-      has: page.getByRole("checkbox", { name: "Toggle Capture inspiration" })
-    });
+    const newTaskCard = page.getByTestId("task-card").filter({ hasText: "Capture inspiration" }).first();
 
     await expect(newTaskCard).toBeVisible();
-    await expect(newTaskCard.getByText("Capture inspiration", { exact: false })).toBeVisible();
-    await expect(newTaskCard.getByText("2025-08-15", { exact: true })).toBeVisible();
-    await expect(newTaskCard.getByText("#inbox", { exact: true })).toBeVisible();
+    await expect(newTaskCard.getByTestId("task-title")).toContainText("Capture inspiration");
+    await expect(newTaskCard.getByTestId("task-due")).toHaveText(/2025-08-15/);
+    await expect(newTaskCard.getByTestId("task-hashtag").filter({ hasText: "#inbox" })).toBeVisible();
   });
 
   test("shows an empty state when no tasks are parsed", async ({ page }) => {
     await loadDocument(page, "");
 
-    const emptyState = page.getByText("No tasks parsed yet — start typing in the editor to see them here.", {
-      exact: true
-    });
+    const emptyState = page.getByTestId("tasks-empty-state");
 
     await expect(emptyState).toBeVisible();
   });
@@ -78,12 +70,10 @@ test.describe("interactive preview", () => {
   test("persists toggled tasks back into markdown", async ({ page }) => {
     await loadDocument(page, "- [ ] Verify persistence");
 
-    const checkbox = page.getByRole("checkbox", { name: "Toggle Verify persistence" });
+    const taskCard = page.getByTestId("task-card").filter({ hasText: "Verify persistence" }).first();
+    const checkbox = taskCard.getByTestId("task-checkbox");
     await checkbox.check();
 
-    const taskCard = page.locator("li", {
-      has: checkbox
-    });
     await expect(taskCard).toHaveAttribute("data-completed", "true");
 
     const storedMarkdown = await getStoredMarkdown(page);

--- a/apps/web/src/lib/panels/preview/InteractivePreviewPanel.svelte
+++ b/apps/web/src/lib/panels/preview/InteractivePreviewPanel.svelte
@@ -70,7 +70,7 @@
 
   {#if view === "tasks"}
     {#if tasks.length === 0}
-      <div class="flex flex-1 items-center justify-center px-6">
+      <div class="flex flex-1 items-center justify-center px-6" data-testid="tasks-empty-state">
         <p
           class="rounded-full border border-dashed border-base-300/80 bg-base-100/80 px-6 py-3 text-sm text-base-content/60"
         >
@@ -78,7 +78,7 @@
         </p>
       </div>
     {:else}
-      <ul class="flex flex-1 flex-col gap-3 overflow-y-auto px-6 pb-6 pt-4">
+      <ul class="flex flex-1 flex-col gap-3 overflow-y-auto px-6 pb-6 pt-4" data-testid="tasks-list">
         {#each tasks as task (task.id)}
           {@const dueLabel = getDueLabel(task)}
           {@const hashtags = getHashtags(task)}
@@ -86,6 +86,7 @@
           <li
             class="rounded-2xl border border-base-300/70 bg-base-100/70 p-3 shadow-sm transition hover:border-primary/40 hover:bg-base-100"
             data-completed={task.checked}
+            data-testid="task-card"
           >
             <label class="group flex items-start gap-4">
               <span class="relative mt-1 flex h-5 w-5 items-center justify-center">
@@ -95,6 +96,8 @@
                   checked={task.checked}
                   on:change={() => handleToggle(task.id)}
                   aria-label={`Toggle ${task.title}`}
+                  data-testid="task-checkbox"
+                  data-task-id={task.id}
                 />
                 <span
                   class="pointer-events-none absolute inset-0 rounded-full border-2 border-base-content/30 bg-base-200/80 transition-all duration-200 peer-checked:border-primary peer-checked:bg-primary/90"
@@ -116,14 +119,16 @@
                     class={`text-base font-semibold leading-snug transition ${
                       task.checked ? "text-base-content/50 line-through" : "text-base-content"
                     }`}
+                    data-testid="task-title"
                   >
                     {task.title}
                   </p>
                   {#if hashtags.length > 0}
-                    <div class="flex flex-wrap justify-end gap-2">
+                    <div class="flex flex-wrap justify-end gap-2" data-testid="task-hashtags">
                       {#each hashtags as tag (tag)}
                         <span
                           class="badge badge-sm border-0 bg-base-300/70 text-[0.65rem] font-semibold uppercase tracking-wide text-base-content/70"
+                          data-testid="task-hashtag"
                         >
                           #{tag}
                         </span>
@@ -134,7 +139,7 @@
 
                 <div class="flex flex-wrap items-center gap-2 text-xs text-base-content/70 sm:text-sm">
                   {#if dueLabel}
-                    <span class="badge badge-sm border-0 bg-success/20 text-success-content/90">
+                    <span class="badge badge-sm border-0 bg-success/20 text-success-content/90" data-testid="task-due">
                       <svg
                         xmlns="http://www.w3.org/2000/svg"
                         viewBox="0 0 24 24"
@@ -150,7 +155,10 @@
                   {/if}
 
                   {#each otherTags as [key, value] (key)}
-                    <span class="badge badge-sm border border-base-300/70 bg-base-100/70 text-base-content/70">
+                    <span
+                      class="badge badge-sm border border-base-300/70 bg-base-100/70 text-base-content/70"
+                      data-testid="task-tag"
+                    >
                       <span class="font-semibold capitalize">{key}</span>
                       <span class="ml-1 text-base-content/60">{value}</span>
                     </span>


### PR DESCRIPTION
## Summary
- add `data-testid` hooks to interactive preview markup for tasks, badges, and empty states
- simplify the Playwright E2E suites to target the new test ids

## Testing
- pnpm test:e2e *(fails: Command "playwright" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d6f322a77c8329ab9210512f84a917