### PR TITLE
Add data-testid for save indicator

### DIFF
--- a/apps/web/e2e/steps/save-indicator.steps.ts
+++ b/apps/web/e2e/steps/save-indicator.steps.ts
@@ -10,7 +10,7 @@ type SaveStatusUpdate = {
   timestamp?: string | number | null;
 };
 
-const SAVE_INDICATOR_SELECTOR = "[data-kind]";
+const SAVE_INDICATOR_SELECTOR = '[data-testid="save-indicator"]';
 
 let currentSaveStatusKind: SaveStatusKind = "idle";
 let lastTimestampIso: string | null = null;

--- a/apps/web/src/lib/app-shell/SaveIndicator.svelte
+++ b/apps/web/src/lib/app-shell/SaveIndicator.svelte
@@ -55,6 +55,7 @@
   <span
     class={badgeClasses}
     data-kind={status.kind}
+    data-testid="save-indicator"
     aria-live="polite"
     role="status"
     title={tooltipMessage}

--- a/apps/web/src/lib/app-shell/SaveIndicator.test.ts
+++ b/apps/web/src/lib/app-shell/SaveIndicator.test.ts
@@ -17,7 +17,8 @@ describe("SaveIndicator", () => {
   it("renders idle state with local save guidance", () => {
     render(SaveIndicator);
 
-    const indicator = screen.getByLabelText(/Saved locally/);
+    const indicator = screen.getByTestId("save-indicator");
+    expect(indicator).toHaveAccessibleName(/Saved locally/);
     expect(indicator).toHaveAttribute("data-kind", "idle");
     expect(indicator).toHaveAttribute("title", localTooltip);
     expect(within(indicator).getByText("Saved locally ✓")).toBeVisible();
@@ -32,7 +33,8 @@ describe("SaveIndicator", () => {
     markSaving();
     await tick();
 
-    const indicator = screen.getByLabelText(/Saving locally/);
+    const indicator = screen.getByTestId("save-indicator");
+    expect(indicator).toHaveAccessibleName(/Saving locally/);
     expect(indicator).toHaveAttribute("data-kind", "saving");
     expect(indicator).toHaveAttribute("title", localTooltip);
     const label = within(indicator).getByText("Saving locally…");
@@ -49,7 +51,8 @@ describe("SaveIndicator", () => {
     markSaved();
     await tick();
 
-    const indicator = screen.getByLabelText(/Saved locally/);
+    const indicator = screen.getByTestId("save-indicator");
+    expect(indicator).toHaveAccessibleName(/Saved locally/);
     expect(indicator).toHaveAttribute("data-kind", "saved");
     const timestamp = within(indicator).getByText(/\(.+:.+\)/);
     expect(timestamp.textContent).toMatch(/^\(.+\)$/);
@@ -61,7 +64,8 @@ describe("SaveIndicator", () => {
     markError(new Error("Disk full"));
     await tick();
 
-    const indicator = screen.getByLabelText(/Disk full/);
+    const indicator = screen.getByTestId("save-indicator");
+    expect(indicator).toHaveAccessibleName(/Disk full/);
     expect(indicator).toHaveAttribute("data-kind", "error");
     expect(indicator).toHaveAttribute("title", errorTooltip);
     expect(within(indicator).getByText("Disk full")).toBeVisible();


### PR DESCRIPTION
## Summary
- add a `data-testid` attribute to the save indicator component for stable selection
- adjust save indicator unit and e2e tests to target the new test id while keeping accessibility checks

## Testing
- pnpm test:unit

------
https://chatgpt.com/codex/tasks/task_e_68d6f4ece6548329a089e458018a3a3e