### PR TITLE
Fix save indicator locator for e2e tests

### DIFF
--- a/apps/web/e2e/steps/save-indicator.steps.ts
+++ b/apps/web/e2e/steps/save-indicator.steps.ts
@@ -10,7 +10,7 @@ type SaveStatusUpdate = {
   timestamp?: string | number | null;
 };
 
-const SAVE_INDICATOR_SELECTOR = "[data-kind]";
+const SAVE_INDICATOR_SELECTOR = '[data-testid="save-indicator"]';
 
 let currentSaveStatusKind: SaveStatusKind = "idle";
 let lastTimestampIso: string | null = null;

--- a/apps/web/src/lib/app-shell/SaveIndicator.svelte
+++ b/apps/web/src/lib/app-shell/SaveIndicator.svelte
@@ -55,6 +55,7 @@
   <span
     class={badgeClasses}
     data-kind={status.kind}
+    data-testid="save-indicator"
     aria-live="polite"
     role="status"
     title={tooltipMessage}


### PR DESCRIPTION
## Summary
- add a dedicated data-testid attribute to the save indicator badge
- update the save indicator e2e step definitions to use the new selector

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6f4fe3bbc8329b2e406a9af338d05