### PR TITLE
Use test id to stabilize app shell layout e2e checks

### DIFF
--- a/apps/web/e2e/steps/shell.steps.ts
+++ b/apps/web/e2e/steps/shell.steps.ts
@@ -3,7 +3,7 @@ import { createBdd } from "playwright-bdd";
 
 const { When, Then } = createBdd();
 
-const layoutSelector = "div[data-layout][data-mode]";
+const shellTestId = "app-shell";
 
 const viewModeIds = new Map<string, string>([
   ["Editor & preview", "editor-preview"],
@@ -60,12 +60,12 @@ When("I resize the viewport to {string}", async ({ page }, layout: string) => {
   await page.setViewportSize(viewport);
 
   const targetLayout = normalized === "mobile" ? "mobile" : "desktop";
-  const shell = page.locator(layoutSelector).first();
+  const shell = page.getByTestId(shellTestId);
   await expect(shell).toHaveAttribute("data-layout", targetLayout);
 });
 
 Then("the layout should be {string}", async ({ page }, layout: string) => {
-  const shell = page.locator(layoutSelector).first();
+  const shell = page.getByTestId(shellTestId);
   await expect(shell).toHaveAttribute("data-layout", layout);
 });
 

--- a/apps/web/src/lib/app-shell/AppShell.svelte
+++ b/apps/web/src/lib/app-shell/AppShell.svelte
@@ -64,7 +64,7 @@
   }
 </script>
 
-<div class="app-shell" data-layout={layout} data-mode={viewMode}>
+<div class="app-shell" data-testid="app-shell" data-layout={layout} data-mode={viewMode}>
   <Toolbar {version} />
   <main class={mainClasses()} data-layout={layout}>
     {#each visiblePanels as panel (panel.id)}


### PR DESCRIPTION
## Summary
- add a stable data-testid attribute to the AppShell root element
- update layout step definitions to assert against the new test id

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6f518ae988329af195be9692a8e38