### PR TITLE
Refactor state store primary document helpers

### DIFF
--- a/apps/web/src/lib/stores/state.constants.ts
+++ b/apps/web/src/lib/stores/state.constants.ts
@@ -1,0 +1,41 @@
+import type { DocumentIndexEntry, DocumentSnapshot } from "./storage";
+
+export const PRIMARY_DOCUMENT_ID = "kelpie-primary-document" as const;
+export const PRIMARY_DOCUMENT_TITLE = "My tasks" as const;
+
+export const DEFAULT_DOCUMENT_CONTENT = `# Welcome to Kelpie 🧭
+
+Kelpie keeps your Markdown to-dos editable anywhere while the app reflects every change in real-time. Use it as a playground to
+learn how Markdown tasks, metadata, and filters come together.
+
+## Try the guided tour
+
+- [ ] Take the welcome tour _(toggle this to see instant syncing)_
+  - [ ] Edit this sub-task in your editor and watch Kelpie follow along
+- [ ] Add scheduling metadata @due(2024-07-01) @priority(A)
+- [ ] Explore repeating tasks @repeat(1w)
+- [ ] Tag workstreams with #planning #inbox
+- [ ] Mark something done and note the timestamp @done(2024-06-01T09:00:00Z)
+
+> Tip: Paste additional Markdown below to experiment—Kelpie renders a split-pane editor and preview so you can iterate quickly.`;
+
+export function createPrimaryDocument(timestamp: string): DocumentSnapshot {
+  return {
+    id: PRIMARY_DOCUMENT_ID,
+    title: PRIMARY_DOCUMENT_TITLE,
+    content: DEFAULT_DOCUMENT_CONTENT,
+    createdAt: timestamp,
+    updatedAt: timestamp
+  };
+}
+
+export function createIndexEntryFromDocument(document: DocumentSnapshot): DocumentIndexEntry {
+  return {
+    id: document.id,
+    title: document.title,
+    createdAt: document.createdAt,
+    updatedAt: document.updatedAt,
+    deletedAt: null,
+    purgeAfter: null
+  };
+}

--- a/apps/web/src/lib/stores/state.test.ts
+++ b/apps/web/src/lib/stores/state.test.ts
@@ -1,6 +1,7 @@
 import { get, writable } from "svelte/store";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { DocumentSnapshot, StorageSnapshot } from "./storage";
+import { DEFAULT_DOCUMENT_CONTENT, PRIMARY_DOCUMENT_ID, PRIMARY_DOCUMENT_TITLE } from "./state.constants";
 import { parseMarkdown } from "../parsing/parseTask";
 
 const BASE_TIMESTAMP = "2024-01-01T00:00:00.000Z";
@@ -47,8 +48,8 @@ function createSnapshot(overrides: Partial<StorageSnapshot> = {}): StorageSnapsh
 
 function createDocument(overrides: Partial<DocumentSnapshot> = {}): DocumentSnapshot {
   const base: DocumentSnapshot = {
-    id: "kelpie-primary-document",
-    title: "My tasks",
+    id: PRIMARY_DOCUMENT_ID,
+    title: PRIMARY_DOCUMENT_TITLE,
     content: "- [ ] Sample",
     createdAt: BASE_TIMESTAMP,
     updatedAt: BASE_TIMESTAMP
@@ -140,13 +141,13 @@ describe("state store", () => {
     expect(updateMock).toHaveBeenCalledTimes(1);
 
     const snapshot = getSnapshot();
-    expect(snapshot.settings.lastActiveDocumentId).toBe("kelpie-primary-document");
-    expect(snapshot.documents["kelpie-primary-document"]).toBeTruthy();
+    expect(snapshot.settings.lastActiveDocumentId).toBe(PRIMARY_DOCUMENT_ID);
+    expect(snapshot.documents[PRIMARY_DOCUMENT_ID]).toBeTruthy();
     expect(snapshot.index).toHaveLength(1);
 
     const stateValue = get(appState);
-    expect(stateValue.documentId).toBe("kelpie-primary-document");
-    expect(stateValue.file).toContain("Welcome to Kelpie");
+    expect(stateValue.documentId).toBe(PRIMARY_DOCUMENT_ID);
+    expect(stateValue.file).toBe(DEFAULT_DOCUMENT_CONTENT);
   });
 
   it("updates the active document content while tracking persistence status", async () => {


### PR DESCRIPTION
## Summary
- extract primary document constants and helper builders into a dedicated module
- refactor the state store bootstrapping logic to use smaller helpers for documents, index, and settings updates
- update the state store tests to rely on the shared constants for the primary document metadata

## Testing
- pnpm --filter web test:unit -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d6f5f1ba4c8329a1af6eb6a1788c29