### PR TITLE
Fix AppShell panel slot rendering

### DIFF
--- a/apps/web/src/lib/app-shell/AppShell.svelte
+++ b/apps/web/src/lib/app-shell/AppShell.svelte
@@ -75,7 +75,13 @@
         data-panel={panel.id}
       >
         <div class="app-shell__panel-content">
-          <slot name={panel.slot} />
+          {#if panel.slot === "editor"}
+            <slot name="editor" />
+          {:else if panel.slot === "preview"}
+            <slot name="preview" />
+          {:else if panel.slot === "settings"}
+            <slot name="settings" />
+          {/if}
         </div>
       </section>
     {/each}


### PR DESCRIPTION
## Summary
- replace the dynamic slot name in `AppShell.svelte` with explicit checks for each panel
- ensure each panel renders its associated static slot name so Vite/Svelte can compile

## Testing
- pnpm --filter web build

------
https://chatgpt.com/codex/tasks/task_e_68d6f6e97a808329a8d0efcef03b494e