### PR TITLE
Simplify E2E selectors with test ids

### DIFF
--- a/apps/web/e2e/interactive-preview.test.ts
+++ b/apps/web/e2e/interactive-preview.test.ts
@@ -31,13 +31,11 @@ test.describe("interactive preview", () => {
     return payload.file;
   }
 
-  function escapeAttribute(value: string): string {
-    return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
-  }
-
   function taskCardByTitle(page: Page, title: string): Locator {
-    const escapedTitle = escapeAttribute(title);
-    return page.locator(`[data-testid="task-card"][data-task-title="${escapedTitle}"]`).first();
+    return page
+      .getByTestId("task-card")
+      .filter({ has: page.getByTestId("task-title").filter({ hasText: title }) })
+      .first();
   }
 
   test("renders metadata badges for parsed tasks", async ({ page }) => {

--- a/apps/web/e2e/steps/tasks.steps.ts
+++ b/apps/web/e2e/steps/tasks.steps.ts
@@ -3,17 +3,12 @@ import { expect, type Locator, type Page } from "@playwright/test";
 
 const { When, Then } = createBdd();
 
-function escapeAttribute(value: string): string {
-  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
-}
-
 function markdownEditor(page: Page): Locator {
   return page.getByTestId("markdown-editor");
 }
 
 function taskTitleLocator(page: Page, title: string): Locator {
-  const escapedTitle = escapeAttribute(title);
-  return page.locator(`[data-testid="task-title"][data-task-title="${escapedTitle}"]`).first();
+  return page.getByTestId("task-title").filter({ hasText: title }).first();
 }
 
 When("I reload the app", async ({ page }) => {

--- a/apps/web/e2e/steps/toggle.steps.ts
+++ b/apps/web/e2e/steps/toggle.steps.ts
@@ -4,13 +4,11 @@ import { expect } from "@playwright/test";
 
 const { When, Then } = createBdd();
 
-function escapeAttribute(value: string): string {
-  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
-}
-
 function taskCard(page: Page, title: string): Locator {
-  const escapedTitle = escapeAttribute(title);
-  return page.locator(`[data-testid="task-card"][data-task-title="${escapedTitle}"]`).first();
+  return page
+    .getByTestId("task-card")
+    .filter({ has: page.getByTestId("task-title").filter({ hasText: title }) })
+    .first();
 }
 
 When("I toggle {string}", async ({ page }: { page: Page }, title: string) => {

--- a/apps/web/src/lib/panels/preview/InteractivePreviewPanel.svelte
+++ b/apps/web/src/lib/panels/preview/InteractivePreviewPanel.svelte
@@ -87,7 +87,6 @@
             class="rounded-2xl border border-base-300/70 bg-base-100/70 p-3 shadow-sm transition hover:border-primary/40 hover:bg-base-100"
             data-completed={task.checked}
             data-testid="task-card"
-            data-task-title={task.title}
           >
             <label class="group flex items-start gap-4">
               <span class="relative mt-1 flex h-5 w-5 items-center justify-center">
@@ -99,7 +98,6 @@
                   aria-label={`Toggle ${task.title}`}
                   data-testid="task-checkbox"
                   data-task-id={task.id}
-                  data-task-title={task.title}
                 />
                 <span
                   class="pointer-events-none absolute inset-0 rounded-full border-2 border-base-content/30 bg-base-200/80 transition-all duration-200 peer-checked:border-primary peer-checked:bg-primary/90"
@@ -122,7 +120,6 @@
                       task.checked ? "text-base-content/50 line-through" : "text-base-content"
                     }`}
                     data-testid="task-title"
-                    data-task-title={task.title}
                   >
                     {task.title}
                   </p>


### PR DESCRIPTION
## Summary
- refactor interactive preview e2e helpers to rely on Playwright test IDs instead of escaped attribute selectors
- remove redundant data-task-title attributes from the interactive preview markup

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d6f92dd90083299d3dde414d0f39e7