### PR TITLE
Refactor panel metadata and toggles for maintainability

### DIFF
--- a/apps/web/src/lib/app-shell/AppShell.svelte
+++ b/apps/web/src/lib/app-shell/AppShell.svelte
@@ -4,37 +4,9 @@
   import { onDestroy } from "svelte";
   import Toolbar from "./Toolbar.svelte";
   import { shellState, startLayoutWatcher } from "$lib/stores/shell";
-  import type { PanelId, ViewMode } from "./contracts";
+  import { getVisiblePanels, type PanelDefinition } from "./panels";
 
   export let version = "0.0.0";
-
-  type PanelDefinition = {
-    id: PanelId;
-    label: string;
-    slot: PanelId;
-    isVisible: (mode: ViewMode) => boolean;
-  };
-
-  const PANELS: PanelDefinition[] = [
-    {
-      id: "editor",
-      label: "Code editor",
-      slot: "editor",
-      isVisible: (mode) => mode === "editor-preview"
-    },
-    {
-      id: "preview",
-      label: "Preview",
-      slot: "preview",
-      isVisible: (mode) => mode !== "settings"
-    },
-    {
-      id: "settings",
-      label: "Settings",
-      slot: "settings",
-      isVisible: (mode) => mode === "settings"
-    }
-  ];
 
   let stopLayoutWatcher: (() => void) | undefined;
 
@@ -48,7 +20,7 @@
 
   $: layout = $shellState.layout;
   $: viewMode = $shellState.viewMode;
-  $: visiblePanels = PANELS.filter((panel) => panel.isVisible(viewMode));
+  $: visiblePanels = getVisiblePanels(viewMode);
   $: settingsIsSolo = visiblePanels.length === 1 && visiblePanels[0]?.id === "settings";
 
   function mainClasses(): string {

--- a/apps/web/src/lib/app-shell/AppShell.svelte
+++ b/apps/web/src/lib/app-shell/AppShell.svelte
@@ -4,6 +4,7 @@
   import { onDestroy } from "svelte";
   import Toolbar from "./Toolbar.svelte";
   import { shellState, startLayoutWatcher } from "$lib/stores/shell";
+  import { isPanelAllowedInMode } from "./contracts";
   import { getVisiblePanels, type PanelDefinition } from "./panels";
 
   export let version = "0.0.0";
@@ -43,7 +44,7 @@
       <section
         class={panelClasses(panel)}
         aria-label={panel.label}
-        data-active={panel.isVisible(viewMode)}
+        data-active={isPanelAllowedInMode(panel.id, viewMode)}
         data-panel={panel.id}
       >
         <div class="app-shell__panel-content">

--- a/apps/web/src/lib/app-shell/PanelToggleGroup.svelte
+++ b/apps/web/src/lib/app-shell/PanelToggleGroup.svelte
@@ -1,33 +1,22 @@
 <svelte:options runes={false} />
 
 <script lang="ts">
-  import { PANEL_ORDER, type PanelId, isPanelAllowedInMode } from "./contracts";
   import { activatePanel, shellState } from "$lib/stores/shell";
+  import { type PanelId, isPanelAllowedInMode } from "./contracts";
+  import { getDockButtonClasses, type DockButtonTone } from "./dockButtonClasses";
+  import { PANEL_DEFINITIONS } from "./panels";
 
-  const panelLabels: Record<PanelId, string> = {
-    editor: "Editor",
-    preview: "Preview",
-    settings: "Settings"
-  };
+  const panelOptions = PANEL_DEFINITIONS.map((panel) => ({
+    id: panel.id,
+    label: panel.label,
+    Icon: panel.icon
+  }));
 
   function handlePanelChange(id: PanelId) {
     activatePanel(id);
   }
 
-  function panelButtonClasses(id: PanelId): string {
-    const isActive = $shellState.activePanel === id;
-    const disabled = !isPanelAllowedInMode(id, $shellState.viewMode);
-
-    return [
-      "dock-item btn btn-sm sm:btn-md btn-circle border border-transparent bg-base-100/70 text-base-content/80 shadow-none transition-all duration-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-secondary/70",
-      isActive
-        ? "bg-secondary text-secondary-content shadow-lg shadow-secondary/30 ring-2 ring-secondary/70"
-        : "hover:border-base-300 hover:bg-base-200/70 hover:text-base-content",
-      disabled ? "btn-disabled opacity-40" : ""
-    ]
-      .filter(Boolean)
-      .join(" ");
-  }
+  const panelTone: DockButtonTone = "secondary";
 </script>
 
 {#if $shellState.layout === "mobile"}
@@ -37,43 +26,25 @@
     aria-label="Select active panel"
     data-testid="panel-toggle-group"
   >
-    {#each PANEL_ORDER as panel (panel)}
+    {#each panelOptions as { id, label, Icon } (id)}
+      {@const isActive = $shellState.activePanel === id}
+      {@const isAllowed = isPanelAllowedInMode(id, $shellState.viewMode)}
+      {@const buttonClasses = getDockButtonClasses({
+        tone: panelTone,
+        isActive,
+        disabled: !isAllowed
+      })}
       <button
         type="button"
-        class={panelButtonClasses(panel)}
-        disabled={!isPanelAllowedInMode(panel, $shellState.viewMode)}
-        on:click={() => handlePanelChange(panel)}
-        aria-label={panelLabels[panel]}
-        title={panelLabels[panel]}
-        aria-pressed={$shellState.activePanel === panel}
-        data-testid={`panel-toggle-${panel}`}
+        class={buttonClasses}
+        disabled={!isAllowed}
+        on:click={() => handlePanelChange(id)}
+        aria-label={label}
+        title={label}
+        aria-pressed={isActive}
+        data-testid={`panel-toggle-${id}`}
       >
-        {#if panel === "editor"}
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" class="h-4 w-4">
-            <path stroke-width="1.5" d="m4.5 15.5 6-6 3 3 6-6" />
-            <path stroke-width="1.5" d="M14.5 5.5h5v5" />
-          </svg>
-        {:else if panel === "preview"}
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" class="h-4 w-4">
-            <path stroke-width="1.5" d="M3 12s3.5-5.5 9-5.5S21 12 21 12s-3.5 5.5-9 5.5S3 12 3 12Z" />
-            <circle cx="12" cy="12" r="2.5" stroke-width="1.5" />
-          </svg>
-        {:else}
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" class="h-4 w-4">
-            <path
-              stroke-width="1.5"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 0 0 2.573 1.066c1.543-.89 3.31.877 2.42 2.42a1.724 1.724 0 0 0 1.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 0 0-1.066 2.573c.89 1.543-.877 3.31-2.42 2.42a1.724 1.724 0 0 0-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 0 0-2.573-1.066c-1.543.89-3.31-.877-2.42-2.42a1.724 1.724 0 0 0-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35A1.724 1.724 0 0 0 4.68 7.803c-.89-1.543.877-3.31 2.42-2.42a1.724 1.724 0 0 0 2.572-1.066Z"
-            />
-            <path
-              stroke-width="1.5"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"
-            />
-          </svg>
-        {/if}
+        <svelte:component this={Icon} className="h-4 w-4" />
       </button>
     {/each}
   </div>

--- a/apps/web/src/lib/app-shell/ViewModeToggleButton.svelte
+++ b/apps/web/src/lib/app-shell/ViewModeToggleButton.svelte
@@ -1,24 +1,22 @@
 <svelte:options runes={false} />
 
 <script lang="ts">
-  import type { ViewMode } from "./contracts";
+  import PreviewIcon from "$lib/components/icons/PreviewIcon.svelte";
+  import SettingsIcon from "$lib/components/icons/SettingsIcon.svelte";
+  import SplitViewIcon from "$lib/components/icons/SplitViewIcon.svelte";
   import { setViewMode, shellState } from "$lib/stores/shell";
+  import type { ViewMode } from "./contracts";
+  import { getDockButtonClasses } from "./dockButtonClasses";
 
-  const viewOptions: { id: ViewMode; label: string }[] = [
-    { id: "editor-preview", label: "Editor & preview" },
-    { id: "preview-only", label: "Preview" },
-    { id: "settings", label: "Settings" }
+  const viewOptions: { id: ViewMode; label: string; Icon: typeof SplitViewIcon }[] = [
+    { id: "editor-preview", label: "Editor & preview", Icon: SplitViewIcon },
+    { id: "preview-only", label: "Preview", Icon: PreviewIcon },
+    { id: "settings", label: "Settings", Icon: SettingsIcon }
   ];
 
   function handleViewChange(id: ViewMode) {
     setViewMode(id);
   }
-
-  const baseButtonClasses =
-    "dock-item btn btn-sm sm:btn-md btn-circle border border-transparent bg-base-100/70 text-base-content/80 shadow-none transition-all duration-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary/70";
-
-  const activeButtonClasses = "bg-primary text-primary-content shadow-lg shadow-primary/30 ring-2 ring-primary/70";
-  const inactiveButtonClasses = "hover:border-base-300 hover:bg-base-200/70 hover:text-base-content";
 </script>
 
 <div
@@ -27,41 +25,17 @@
   aria-label="Select workspace mode"
 >
   {#each viewOptions as option (option.id)}
+    {@const isActive = $shellState.viewMode === option.id}
     <button
       type="button"
-      class={`${baseButtonClasses} ${$shellState.viewMode === option.id ? activeButtonClasses : inactiveButtonClasses}`}
+      class={getDockButtonClasses({ tone: "primary", isActive })}
       on:click={() => handleViewChange(option.id)}
-      aria-pressed={$shellState.viewMode === option.id}
+      aria-pressed={isActive}
       aria-label={option.label}
       title={option.label}
       data-testid={`view-mode-${option.id}`}
     >
-      {#if option.id === "editor-preview"}
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" class="h-5 w-5">
-          <rect x="3.5" y="5.5" width="7" height="13" rx="1.5" stroke-width="1.5" />
-          <rect x="13.5" y="5.5" width="7" height="13" rx="1.5" stroke-width="1.5" />
-        </svg>
-      {:else if option.id === "preview-only"}
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" class="h-5 w-5">
-          <path stroke-width="1.5" d="M3 12s3.5-5.5 9-5.5S21 12 21 12s-3.5 5.5-9 5.5S3 12 3 12Z" />
-          <circle cx="12" cy="12" r="2.5" stroke-width="1.5" />
-        </svg>
-      {:else}
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" class="h-5 w-5">
-          <path
-            stroke-width="1.5"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 0 0 2.573 1.066c1.543-.89 3.31.877 2.42 2.42a1.724 1.724 0 0 0 1.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 0 0-1.066 2.573c.89 1.543-.877 3.31-2.42 2.42a1.724 1.724 0 0 0-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 0 0-2.573-1.066c-1.543.89-3.31-.877-2.42-2.42a1.724 1.724 0 0 0-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35A1.724 1.724 0 0 0 4.68 7.803c-.89-1.543.877-3.31 2.42-2.42a1.724 1.724 0 0 0 2.572-1.066Z"
-          />
-          <path
-            stroke-width="1.5"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"
-          />
-        </svg>
-      {/if}
+      <svelte:component this={option.Icon} className="h-5 w-5" />
     </button>
   {/each}
 </div>

--- a/apps/web/src/lib/app-shell/contracts.ts
+++ b/apps/web/src/lib/app-shell/contracts.ts
@@ -35,8 +35,6 @@ export type ShellState = {
   activePanel: PanelId;
 };
 
-export const PANEL_ORDER: PanelId[] = ["editor", "preview", "settings"];
-
 export function defaultPanelForMode(mode: ViewMode): PanelId {
   if (mode === "settings") return "settings";
   if (mode === "preview-only") return "preview";

--- a/apps/web/src/lib/app-shell/dockButtonClasses.ts
+++ b/apps/web/src/lib/app-shell/dockButtonClasses.ts
@@ -1,0 +1,36 @@
+const baseDockButtonClasses =
+  "dock-item btn btn-sm sm:btn-md btn-circle border border-transparent bg-base-100/70 text-base-content/80 shadow-none transition-all duration-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2";
+
+const toneFocusClasses = {
+  primary: "focus-visible:outline-primary/70",
+  secondary: "focus-visible:outline-secondary/70"
+} as const;
+
+const activeStateClasses = {
+  primary: "bg-primary text-primary-content shadow-lg shadow-primary/30 ring-2 ring-primary/70",
+  secondary: "bg-secondary text-secondary-content shadow-lg shadow-secondary/30 ring-2 ring-secondary/70"
+} as const;
+
+const inactiveStateClasses = "hover:border-base-300 hover:bg-base-200/70 hover:text-base-content";
+const disabledStateClasses = "btn-disabled opacity-40";
+
+export type DockButtonTone = keyof typeof activeStateClasses;
+
+export function getDockButtonClasses({
+  tone,
+  isActive,
+  disabled = false
+}: {
+  tone: DockButtonTone;
+  isActive: boolean;
+  disabled?: boolean;
+}): string {
+  return [
+    baseDockButtonClasses,
+    toneFocusClasses[tone],
+    isActive ? activeStateClasses[tone] : inactiveStateClasses,
+    disabled ? disabledStateClasses : ""
+  ]
+    .filter((value) => value.length > 0)
+    .join(" ");
+}

--- a/apps/web/src/lib/app-shell/panels.ts
+++ b/apps/web/src/lib/app-shell/panels.ts
@@ -1,14 +1,13 @@
 import EditorIcon from "$lib/components/icons/EditorIcon.svelte";
 import PreviewIcon from "$lib/components/icons/PreviewIcon.svelte";
 import SettingsIcon from "$lib/components/icons/SettingsIcon.svelte";
-import type { PanelId, ViewMode } from "./contracts";
+import { isPanelAllowedInMode, type PanelId, type ViewMode } from "./contracts";
 
 export type PanelDefinition = {
   id: PanelId;
   label: string;
   slot: PanelId;
   icon: typeof EditorIcon;
-  isVisible: (mode: ViewMode) => boolean;
 };
 
 const definitions = [
@@ -16,22 +15,19 @@ const definitions = [
     id: "editor",
     label: "Code editor",
     slot: "editor",
-    icon: EditorIcon,
-    isVisible: (mode: ViewMode) => mode === "editor-preview"
+    icon: EditorIcon
   },
   {
     id: "preview",
     label: "Preview",
     slot: "preview",
-    icon: PreviewIcon,
-    isVisible: (mode: ViewMode) => mode !== "settings"
+    icon: PreviewIcon
   },
   {
     id: "settings",
     label: "Settings",
     slot: "settings",
-    icon: SettingsIcon,
-    isVisible: (mode: ViewMode) => mode === "settings"
+    icon: SettingsIcon
   }
 ] satisfies PanelDefinition[];
 
@@ -42,5 +38,5 @@ export const PANEL_LABELS: Record<PanelId, string> = Object.fromEntries(
 ) as Record<PanelId, string>;
 
 export function getVisiblePanels(mode: ViewMode): PanelDefinition[] {
-  return definitions.filter((panel) => panel.isVisible(mode));
+  return definitions.filter((panel) => isPanelAllowedInMode(panel.id, mode));
 }

--- a/apps/web/src/lib/app-shell/panels.ts
+++ b/apps/web/src/lib/app-shell/panels.ts
@@ -1,0 +1,46 @@
+import EditorIcon from "$lib/components/icons/EditorIcon.svelte";
+import PreviewIcon from "$lib/components/icons/PreviewIcon.svelte";
+import SettingsIcon from "$lib/components/icons/SettingsIcon.svelte";
+import type { PanelId, ViewMode } from "./contracts";
+
+export type PanelDefinition = {
+  id: PanelId;
+  label: string;
+  slot: PanelId;
+  icon: typeof EditorIcon;
+  isVisible: (mode: ViewMode) => boolean;
+};
+
+const definitions = [
+  {
+    id: "editor",
+    label: "Code editor",
+    slot: "editor",
+    icon: EditorIcon,
+    isVisible: (mode: ViewMode) => mode === "editor-preview"
+  },
+  {
+    id: "preview",
+    label: "Preview",
+    slot: "preview",
+    icon: PreviewIcon,
+    isVisible: (mode: ViewMode) => mode !== "settings"
+  },
+  {
+    id: "settings",
+    label: "Settings",
+    slot: "settings",
+    icon: SettingsIcon,
+    isVisible: (mode: ViewMode) => mode === "settings"
+  }
+] satisfies PanelDefinition[];
+
+export const PANEL_DEFINITIONS = definitions;
+
+export const PANEL_LABELS: Record<PanelId, string> = Object.fromEntries(
+  definitions.map((panel) => [panel.id, panel.label])
+) as Record<PanelId, string>;
+
+export function getVisiblePanels(mode: ViewMode): PanelDefinition[] {
+  return definitions.filter((panel) => panel.isVisible(mode));
+}

--- a/apps/web/src/lib/components/icons/EditorIcon.svelte
+++ b/apps/web/src/lib/components/icons/EditorIcon.svelte
@@ -1,0 +1,10 @@
+<svelte:options runes={false} />
+
+<script lang="ts">
+  export let className = "h-4 w-4";
+</script>
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" class={className}>
+  <path stroke-width="1.5" d="m4.5 15.5 6-6 3 3 6-6" />
+  <path stroke-width="1.5" d="M14.5 5.5h5v5" />
+</svg>

--- a/apps/web/src/lib/components/icons/PreviewIcon.svelte
+++ b/apps/web/src/lib/components/icons/PreviewIcon.svelte
@@ -1,0 +1,10 @@
+<svelte:options runes={false} />
+
+<script lang="ts">
+  export let className = "h-4 w-4";
+</script>
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" class={className}>
+  <path stroke-width="1.5" d="M3 12s3.5-5.5 9-5.5S21 12 21 12s-3.5 5.5-9 5.5S3 12 3 12Z" />
+  <circle cx="12" cy="12" r="2.5" stroke-width="1.5" />
+</svg>

--- a/apps/web/src/lib/components/icons/SettingsIcon.svelte
+++ b/apps/web/src/lib/components/icons/SettingsIcon.svelte
@@ -1,0 +1,15 @@
+<svelte:options runes={false} />
+
+<script lang="ts">
+  export let className = "h-4 w-4";
+</script>
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" class={className}>
+  <path
+    stroke-width="1.5"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 0 0 2.573 1.066c1.543-.89 3.31.877 2.42 2.42a1.724 1.724 0 0 0 1.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 0 0-1.066 2.573c.89 1.543-.877 3.31-2.42 2.42a1.724 1.724 0 0 0-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 0 0-2.573-1.066c-1.543.89-3.31-.877-2.42-2.42a1.724 1.724 0 0 0-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35A1.724 1.724 0 0 0 4.68 7.803c-.89-1.543.877-3.31 2.42-2.42a1.724 1.724 0 0 0 2.572-1.066Z"
+  />
+  <path stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
+</svg>

--- a/apps/web/src/lib/components/icons/SplitViewIcon.svelte
+++ b/apps/web/src/lib/components/icons/SplitViewIcon.svelte
@@ -1,0 +1,10 @@
+<svelte:options runes={false} />
+
+<script lang="ts">
+  export let className = "h-5 w-5";
+</script>
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" class={className}>
+  <rect x="3.5" y="5.5" width="7" height="13" rx="1.5" stroke-width="1.5" />
+  <rect x="13.5" y="5.5" width="7" height="13" rx="1.5" stroke-width="1.5" />
+</svg>


### PR DESCRIPTION
## Summary
- centralize panel metadata and icons for the app shell panels
- reuse shared dock button styling logic across panel and view mode toggles
- replace inline SVGs with dedicated icon components for improved reuse

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d6f8749bc083298868ca184d3f0b67