### PR TITLE
Use ViewMode enum to drive panel definitions

### DIFF
--- a/apps/web/src/lib/app-shell/ViewModeToggleButton.svelte
+++ b/apps/web/src/lib/app-shell/ViewModeToggleButton.svelte
@@ -5,13 +5,13 @@
   import SettingsIcon from "$lib/components/icons/SettingsIcon.svelte";
   import SplitViewIcon from "$lib/components/icons/SplitViewIcon.svelte";
   import { setViewMode, shellState } from "$lib/stores/shell";
-  import type { ViewMode } from "./contracts";
+  import { ViewMode } from "./contracts";
   import { getDockButtonClasses } from "./dockButtonClasses";
 
   const viewOptions: { id: ViewMode; label: string; Icon: typeof SplitViewIcon }[] = [
-    { id: "editor-preview", label: "Editor & preview", Icon: SplitViewIcon },
-    { id: "preview-only", label: "Preview", Icon: PreviewIcon },
-    { id: "settings", label: "Settings", Icon: SettingsIcon }
+    { id: ViewMode.EditorPreview, label: "Editor & preview", Icon: SplitViewIcon },
+    { id: ViewMode.PreviewOnly, label: "Preview", Icon: PreviewIcon },
+    { id: ViewMode.Settings, label: "Settings", Icon: SettingsIcon }
   ];
 
   function handleViewChange(id: ViewMode) {

--- a/apps/web/src/lib/app-shell/contracts.ts
+++ b/apps/web/src/lib/app-shell/contracts.ts
@@ -10,7 +10,11 @@ export type PanelId = "editor" | "preview" | "settings";
  * - `preview-only`: only the preview should be visible.
  * - `settings`: settings replace the main workspace.
  */
-export type ViewMode = "editor-preview" | "preview-only" | "settings";
+export enum ViewMode {
+  EditorPreview = "editor-preview",
+  PreviewOnly = "preview-only",
+  Settings = "settings"
+}
 
 /**
  * Shell layout state derived from viewport size.
@@ -36,16 +40,16 @@ export type ShellState = {
 };
 
 export function defaultPanelForMode(mode: ViewMode): PanelId {
-  if (mode === "settings") return "settings";
-  if (mode === "preview-only") return "preview";
+  if (mode === ViewMode.Settings) return "settings";
+  if (mode === ViewMode.PreviewOnly) return "preview";
   return "editor";
 }
 
 export function isPanelAllowedInMode(panel: PanelId, mode: ViewMode): boolean {
-  if (mode === "settings") {
+  if (mode === ViewMode.Settings) {
     return panel === "settings";
   }
-  if (mode === "preview-only") {
+  if (mode === ViewMode.PreviewOnly) {
     return panel === "preview";
   }
   return panel === "editor" || panel === "preview";

--- a/apps/web/src/lib/app-shell/panels.ts
+++ b/apps/web/src/lib/app-shell/panels.ts
@@ -1,7 +1,7 @@
 import EditorIcon from "$lib/components/icons/EditorIcon.svelte";
 import PreviewIcon from "$lib/components/icons/PreviewIcon.svelte";
 import SettingsIcon from "$lib/components/icons/SettingsIcon.svelte";
-import { isPanelAllowedInMode, type PanelId, type ViewMode } from "./contracts";
+import { ViewMode, isPanelAllowedInMode, type PanelId } from "./contracts";
 
 export type PanelDefinition = {
   id: PanelId;
@@ -10,26 +10,28 @@ export type PanelDefinition = {
   icon: typeof EditorIcon;
 };
 
-const definitions = [
-  {
-    id: "editor",
-    label: "Code editor",
-    slot: "editor",
-    icon: EditorIcon
-  },
-  {
-    id: "preview",
-    label: "Preview",
-    slot: "preview",
-    icon: PreviewIcon
-  },
-  {
-    id: "settings",
-    label: "Settings",
-    slot: "settings",
-    icon: SettingsIcon
-  }
-] satisfies PanelDefinition[];
+const PANELS_BY_MODE: Record<ViewMode, PanelId[]> = {
+  [ViewMode.EditorPreview]: ["editor", "preview"],
+  [ViewMode.PreviewOnly]: ["preview"],
+  [ViewMode.Settings]: ["settings"]
+};
+
+type PanelConfig = { label: string; icon: typeof EditorIcon };
+
+const PANEL_CONFIG: Record<PanelId, PanelConfig> = {
+  editor: { label: "Code editor", icon: EditorIcon },
+  preview: { label: "Preview", icon: PreviewIcon },
+  settings: { label: "Settings", icon: SettingsIcon }
+};
+
+const orderedPanels = Array.from(new Set(Object.values(ViewMode).flatMap((mode) => PANELS_BY_MODE[mode]))) as PanelId[];
+
+const definitions = orderedPanels.map((id) => ({
+  id,
+  label: PANEL_CONFIG[id].label,
+  slot: id,
+  icon: PANEL_CONFIG[id].icon
+})) satisfies PanelDefinition[];
 
 export const PANEL_DEFINITIONS = definitions;
 

--- a/apps/web/src/lib/index.ts
+++ b/apps/web/src/lib/index.ts
@@ -5,7 +5,8 @@ export { default as CodeEditorPanel } from "./panels/editor/CodeEditorPanel.svel
 export { default as InteractivePreviewPanel } from "./panels/preview/InteractivePreviewPanel.svelte";
 export { default as AppSettingsPanel } from "./panels/settings/AppSettingsPanel.svelte";
 
-export type { PanelId, ViewMode, ShellLayout, SaveStatus, SaveStatusKind } from "./app-shell/contracts";
+export { ViewMode } from "./app-shell/contracts";
+export type { PanelId, ShellLayout, SaveStatus, SaveStatusKind } from "./app-shell/contracts";
 export { shellState, setLayout, setViewMode, activatePanel, startLayoutWatcher } from "./stores/shell";
 export { saveStatus } from "./stores/persistence";
 

--- a/apps/web/src/lib/stores/shell.test.ts
+++ b/apps/web/src/lib/stores/shell.test.ts
@@ -1,31 +1,31 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { get } from "svelte/store";
 import { activatePanel, setLayout, setViewMode, shellState } from "./shell";
-import { defaultPanelForMode } from "$lib/app-shell/contracts";
+import { ViewMode, defaultPanelForMode } from "$lib/app-shell/contracts";
 
 describe("shell store", () => {
   afterEach(() => {
     setLayout("desktop");
-    setViewMode("editor-preview");
+    setViewMode(ViewMode.EditorPreview);
   });
 
   it("provides default panel for each mode", () => {
-    expect(defaultPanelForMode("editor-preview")).toBe("editor");
-    expect(defaultPanelForMode("preview-only")).toBe("preview");
-    expect(defaultPanelForMode("settings")).toBe("settings");
+    expect(defaultPanelForMode(ViewMode.EditorPreview)).toBe("editor");
+    expect(defaultPanelForMode(ViewMode.PreviewOnly)).toBe("preview");
+    expect(defaultPanelForMode(ViewMode.Settings)).toBe("settings");
   });
 
   it("switches to preview-only mode and updates active panel on mobile", () => {
     setLayout("mobile");
-    setViewMode("preview-only");
+    setViewMode(ViewMode.PreviewOnly);
 
     const state = get(shellState);
-    expect(state.viewMode).toBe("preview-only");
+    expect(state.viewMode).toBe(ViewMode.PreviewOnly);
     expect(state.activePanel).toBe("preview");
   });
 
   it("ignores invalid panel activation in current mode", () => {
-    setViewMode("editor-preview");
+    setViewMode(ViewMode.EditorPreview);
     setLayout("mobile");
     activatePanel("settings");
 

--- a/apps/web/src/lib/stores/shell.ts
+++ b/apps/web/src/lib/stores/shell.ts
@@ -3,14 +3,14 @@ import {
   type PanelId,
   type ShellLayout,
   type ShellState,
-  type ViewMode,
+  ViewMode,
   defaultPanelForMode,
   isPanelAllowedInMode
 } from "$lib/app-shell/contracts";
 
 const initialState: ShellState = {
   layout: "desktop",
-  viewMode: "editor-preview",
+  viewMode: ViewMode.EditorPreview,
   activePanel: "editor"
 };
 


### PR DESCRIPTION
## Summary
- convert the view mode contract to an enum and expose it through the public entrypoint
- derive panel definitions from view-mode aware metadata instead of hard-coded arrays
- update the shell store, toggle component, and tests to consume the enum values

## Testing
- pnpm typecheck *(fails: existing svelte-check issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d6fdaea4e48329a806c4de821a1fd1