### PR TITLE
Refactor dock toggle buttons into reusable component

### DIFF
--- a/apps/web/src/lib/app-shell/DockToggleButton.svelte
+++ b/apps/web/src/lib/app-shell/DockToggleButton.svelte
@@ -1,0 +1,34 @@
+<svelte:options runes={false} />
+
+<script lang="ts">
+  import { createEventDispatcher } from "svelte";
+
+  import { getDockButtonClasses, type DockButtonTone } from "./dockButtonClasses";
+
+  export let id: string;
+  export let label: string;
+  export let tone: DockButtonTone = "primary";
+  export let isActive = false;
+  export let isDisabled = false;
+  export let ariaLabel: string | undefined = undefined;
+  export let title: string | undefined = undefined;
+
+  const dispatch = createEventDispatcher<{ select: string }>();
+
+  function handleClick() {
+    dispatch("select", id);
+  }
+</script>
+
+<button
+  type="button"
+  class={getDockButtonClasses({ tone, isActive, disabled: isDisabled })}
+  disabled={isDisabled}
+  aria-pressed={isActive}
+  aria-label={ariaLabel ?? label}
+  title={title ?? label}
+  on:click={handleClick}
+  {...$$restProps}
+>
+  <slot />
+</button>

--- a/apps/web/src/lib/app-shell/PanelToggleGroup.svelte
+++ b/apps/web/src/lib/app-shell/PanelToggleGroup.svelte
@@ -3,7 +3,8 @@
 <script lang="ts">
   import { activatePanel, shellState } from "$lib/stores/shell";
   import { type PanelId, isPanelAllowedInMode } from "./contracts";
-  import { getDockButtonClasses, type DockButtonTone } from "./dockButtonClasses";
+  import DockToggleButton from "./DockToggleButton.svelte";
+  import { type DockButtonTone } from "./dockButtonClasses";
   import { PANEL_DEFINITIONS } from "./panels";
 
   const panelOptions = PANEL_DEFINITIONS.map((panel) => ({
@@ -29,23 +30,17 @@
     {#each panelOptions as { id, label, Icon } (id)}
       {@const isActive = $shellState.activePanel === id}
       {@const isAllowed = isPanelAllowedInMode(id, $shellState.viewMode)}
-      {@const buttonClasses = getDockButtonClasses({
-        tone: panelTone,
-        isActive,
-        disabled: !isAllowed
-      })}
-      <button
-        type="button"
-        class={buttonClasses}
-        disabled={!isAllowed}
-        on:click={() => handlePanelChange(id)}
-        aria-label={label}
-        title={label}
-        aria-pressed={isActive}
+      <DockToggleButton
+        {id}
+        {label}
+        tone={panelTone}
+        {isActive}
+        isDisabled={!isAllowed}
+        on:select={(event) => handlePanelChange(event.detail as PanelId)}
         data-testid={`panel-toggle-${id}`}
       >
         <svelte:component this={Icon} className="h-4 w-4" />
-      </button>
+      </DockToggleButton>
     {/each}
   </div>
 {/if}

--- a/apps/web/src/lib/app-shell/ViewModeToggleButton.svelte
+++ b/apps/web/src/lib/app-shell/ViewModeToggleButton.svelte
@@ -6,7 +6,7 @@
   import SplitViewIcon from "$lib/components/icons/SplitViewIcon.svelte";
   import { setViewMode, shellState } from "$lib/stores/shell";
   import type { ViewMode } from "./contracts";
-  import { getDockButtonClasses } from "./dockButtonClasses";
+  import DockToggleButton from "./DockToggleButton.svelte";
 
   const viewOptions: { id: ViewMode; label: string; Icon: typeof SplitViewIcon }[] = [
     { id: "editor-preview", label: "Editor & preview", Icon: SplitViewIcon },
@@ -26,16 +26,15 @@
 >
   {#each viewOptions as option (option.id)}
     {@const isActive = $shellState.viewMode === option.id}
-    <button
-      type="button"
-      class={getDockButtonClasses({ tone: "primary", isActive })}
-      on:click={() => handleViewChange(option.id)}
-      aria-pressed={isActive}
-      aria-label={option.label}
-      title={option.label}
+    <DockToggleButton
+      id={option.id}
+      label={option.label}
+      tone="primary"
+      {isActive}
+      on:select={(event) => handleViewChange(event.detail as ViewMode)}
       data-testid={`view-mode-${option.id}`}
     >
       <svelte:component this={option.Icon} className="h-5 w-5" />
-    </button>
+    </DockToggleButton>
   {/each}
 </div>


### PR DESCRIPTION
## Summary
- add a reusable DockToggleButton component that encapsulates styling, accessibility labels, and disabled handling for dock buttons
- refactor the panel and view toggle groups to use the shared component for more consistent markup and easier maintenance

## Testing
- pnpm -C apps/web check *(fails: existing type errors in the project)*

------
https://chatgpt.com/codex/tasks/task_e_68d6fdb942848329a27018dab7301269