### PR TITLE
refactor(storage): rethrow snapshot parse errors

### DIFF
--- a/apps/web/src/lib/stores/storage/broadcast.ts
+++ b/apps/web/src/lib/stores/storage/broadcast.ts
@@ -1,6 +1,7 @@
 import { STORAGE_KEY_ROOT } from "./constants";
 import { getLocalStorage, getWindow } from "./environment";
 import type { StorageDriver } from "./driver";
+import { storageWarn } from "./logging";
 import type { StorageBroadcast } from "./types";
 
 const BROADCAST_CHANNEL_NAME = "kelpie.storage.broadcast";
@@ -40,7 +41,7 @@ function resolveBroadcastChannel(): BroadcastChannel | null {
     broadcastChannel = new ChannelCtor(BROADCAST_CHANNEL_NAME);
     return broadcastChannel;
   } catch (error) {
-    console.warn("Kelpie storage: failed to initialise BroadcastChannel", error);
+    storageWarn("failed to initialise BroadcastChannel", error);
     broadcastChannelBroken = true;
     broadcastChannel = null;
     return null;
@@ -57,7 +58,7 @@ function emitViaBroadcastChannel(broadcast: StorageBroadcast): boolean {
     channel.postMessage(broadcast);
     return true;
   } catch (error) {
-    console.warn("Kelpie storage: failed to post broadcast message", error);
+    storageWarn("failed to post broadcast message", error);
     try {
       channel.close();
     } catch {
@@ -84,7 +85,7 @@ function emitViaStorageEvent(broadcast: StorageBroadcast): void {
   try {
     storage.setItem(BROADCAST_STORAGE_KEY, JSON.stringify(payload));
   } catch (error) {
-    console.warn("Kelpie storage: failed to write broadcast payload", error);
+    storageWarn("failed to write broadcast payload", error);
   }
 }
 

--- a/apps/web/src/lib/stores/storage/driver.test.ts
+++ b/apps/web/src/lib/stores/storage/driver.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createLocalStorageDriver } from "./driver";
+import { STORAGE_LOG_PREFIX } from "./logging";
 import type { StorageSnapshot } from "./types";
 
 const STORAGE_KEY = "kelpie:test-driver";
@@ -54,13 +55,13 @@ describe("createLocalStorageDriver", () => {
     expect(driver.load()).toEqual(SAMPLE_SNAPSHOT);
   });
 
-  it("returns null when the stored payload cannot be parsed", () => {
+  it("re-throws when the stored payload cannot be parsed", () => {
     const driver = createLocalStorageDriver(STORAGE_KEY);
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     globalThis.localStorage.setItem(STORAGE_KEY, "not-json");
 
-    expect(driver.load()).toBeNull();
-    expect(warnSpy).toHaveBeenCalledWith("Kelpie storage: failed to parse snapshot", expect.any(SyntaxError));
+    expect(() => driver.load()).toThrow(SyntaxError);
+    expect(warnSpy).toHaveBeenCalledWith(`${STORAGE_LOG_PREFIX}: failed to parse snapshot`, expect.any(SyntaxError));
   });
 
   it("no-ops when localStorage is unavailable", () => {
@@ -74,7 +75,7 @@ describe("createLocalStorageDriver", () => {
     expect(() => driver.clear()).not.toThrow();
 
     expect(warnSpy).toHaveBeenCalledTimes(3);
-    expect(warnSpy).toHaveBeenCalledWith("Kelpie storage: localStorage is not available");
+    expect(warnSpy).toHaveBeenCalledWith(`${STORAGE_LOG_PREFIX}: localStorage is not available`);
   });
 
   it("subscribes to storage events and filters by key", () => {
@@ -110,7 +111,7 @@ describe("createLocalStorageDriver", () => {
     expect(() => unsubscribe()).not.toThrow();
     expect(callback).not.toHaveBeenCalled();
 
-    expect(warnSpy).toHaveBeenCalledWith("Kelpie storage: window is not available");
+    expect(warnSpy).toHaveBeenCalledWith(`${STORAGE_LOG_PREFIX}: window is not available`);
 
     if (originalWindow) {
       vi.stubGlobal("window", originalWindow);

--- a/apps/web/src/lib/stores/storage/driver.ts
+++ b/apps/web/src/lib/stores/storage/driver.ts
@@ -1,4 +1,5 @@
 import { getLocalStorage, getWindow } from "./environment";
+import { storageWarn } from "./logging";
 import type { StorageSnapshot } from "./types";
 
 /**
@@ -29,8 +30,8 @@ export function createLocalStorageDriver(key: string): StorageDriver {
       try {
         return JSON.parse(raw) as StorageSnapshot;
       } catch (error) {
-        console.warn("Kelpie storage: failed to parse snapshot", error);
-        return null;
+        storageWarn("failed to parse snapshot", error);
+        throw error;
       }
     },
     save(snapshot) {

--- a/apps/web/src/lib/stores/storage/environment.ts
+++ b/apps/web/src/lib/stores/storage/environment.ts
@@ -4,9 +4,11 @@
  * Centralising these checks makes it easier to stub globals in tests
  * and swap implementations when new platforms are supported.
  */
+import { storageWarn } from "./logging";
+
 export function getWindow(): (Window & typeof globalThis) | null {
   if (typeof window === "undefined") {
-    console.warn("Kelpie storage: window is not available");
+    storageWarn("window is not available");
     return null;
   }
 
@@ -15,7 +17,7 @@ export function getWindow(): (Window & typeof globalThis) | null {
 
 export function getLocalStorage(): Storage | null {
   if (typeof localStorage === "undefined") {
-    console.warn("Kelpie storage: localStorage is not available");
+    storageWarn("localStorage is not available");
     return null;
   }
 

--- a/apps/web/src/lib/stores/storage/logging.ts
+++ b/apps/web/src/lib/stores/storage/logging.ts
@@ -1,0 +1,12 @@
+/**
+ * Centralised logging helpers for the storage layer.
+ *
+ * Using a shared prefix keeps console output consistent and
+ * makes it easier to adjust messaging in future maintenance
+ * tasks without touching every call site.
+ */
+export const STORAGE_LOG_PREFIX = "Kelpie storage";
+
+export function storageWarn(message: string, ...details: unknown[]): void {
+  console.warn(`${STORAGE_LOG_PREFIX}: ${message}`, ...details);
+}


### PR DESCRIPTION
## Summary
- rethrow snapshot parse errors from the storage driver so callers can decide how to handle corrupted data
- update the driver unit test to assert that the SyntaxError bubbles while still checking the shared log prefix

## Testing
- pnpm --filter web test:unit -- run src/lib/stores/storage/driver.test.ts src/lib/stores/storage/broadcast.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d6fd00b934832990749b4e04f19964