### PR TITLE
Add toolbar e2e coverage and align spec

### DIFF
--- a/apps/web/e2e/features/toolbar.feature
+++ b/apps/web/e2e/features/toolbar.feature
@@ -1,0 +1,31 @@
+Feature: Toolbar interactions
+  The toolbar keeps core workspace controls accessible across layouts.
+
+  Background:
+    Given I open the app with "basic.md"
+
+  Scenario: Branding tooltip communicates version and purpose
+    Then the toolbar brand tooltip contains "Kelpie 0.0.0-dev"
+    And the tooltip explains it is the markdown to-do studio
+
+  Scenario: Save indicator is always present
+    Then the toolbar displays the save indicator component
+    And the save indicator announces updates politely
+
+  Scenario: View mode switch updates shell state
+    When I choose the "Preview" view mode
+    Then the "Preview" panel should be visible
+    And the "Preview" view mode toggle is marked as active
+
+  Scenario: Theme toggle reflects current theme
+    Given the stored theme preference is cleared
+    When I toggle the theme from the toolbar
+    Then the document theme should be "dark"
+    And the theme toggle label reads "Switch to light theme"
+
+  Scenario: Panel toggle group only appears on mobile layouts
+    When I resize the viewport to "mobile"
+    Then the layout should be "mobile"
+    And the panel toggle group is visible within the toolbar
+    When I resize the viewport to "desktop"
+    Then the panel toggle group is hidden

--- a/apps/web/e2e/steps/toolbar.steps.ts
+++ b/apps/web/e2e/steps/toolbar.steps.ts
@@ -1,0 +1,77 @@
+import { expect } from "@playwright/test";
+import { createBdd } from "playwright-bdd";
+
+const { Given, When, Then } = createBdd();
+
+const viewModeIds = new Map<string, string>([
+  ["editor & preview", "editor-preview"],
+  ["preview", "preview-only"],
+  ["settings", "settings"]
+]);
+
+Then("the toolbar brand tooltip contains {string}", async ({ page }, expected: string) => {
+  const tooltip = page.getByTestId("toolbar-brand-tooltip");
+  await expect(tooltip).toBeVisible();
+  const escaped = expected.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&");
+  await expect(tooltip).toHaveAttribute("data-tip", new RegExp(escaped));
+});
+
+Then("the tooltip explains it is the markdown to-do studio", async ({ page }) => {
+  const tooltip = page.getByTestId("toolbar-brand-tooltip");
+  await expect(tooltip).toHaveAttribute("data-tip", /Markdown to-do studio — edit, preview, and fine-tune your flow\./);
+});
+
+Then("the toolbar displays the save indicator component", async ({ page }) => {
+  await expect(page.getByTestId("save-indicator")).toBeVisible();
+});
+
+Then("the save indicator announces updates politely", async ({ page }) => {
+  const indicator = page.getByTestId("save-indicator");
+  await expect(indicator).toHaveAttribute("aria-live", "polite");
+  await expect(indicator).toHaveAttribute("role", "status");
+});
+
+Then("the {string} view mode toggle is marked as active", async ({ page }, label: string) => {
+  const toggleId = viewModeIds.get(label.trim().toLowerCase()) ?? null;
+  if (!toggleId) {
+    throw new Error(`Unknown view mode label: ${label}`);
+  }
+
+  const toggle = page.getByTestId(`view-mode-${toggleId}`);
+  await expect(toggle).toHaveAttribute("aria-pressed", "true");
+});
+
+Given("the stored theme preference is cleared", async ({ page }) => {
+  await page.evaluate(() => localStorage.removeItem("kelpie-theme"));
+  await page.reload();
+  await expect(page.locator("html")).toHaveAttribute("data-theme", "light");
+});
+
+When("I toggle the theme from the toolbar", async ({ page }) => {
+  const button = page.getByRole("button", { name: "Switch to dark theme" });
+  await expect(button).toBeVisible();
+  await button.click();
+});
+
+Then("the document theme should be {string}", async ({ page }, theme: string) => {
+  await expect(page.locator("html")).toHaveAttribute("data-theme", theme);
+});
+
+Then("the theme toggle label reads {string}", async ({ page }, label: string) => {
+  await expect(page.getByRole("button", { name: label })).toBeVisible();
+});
+
+Then("the panel toggle group is visible within the toolbar", async ({ page }) => {
+  const group = page.getByTestId("panel-toggle-group");
+  await expect(group).toBeVisible();
+});
+
+Then("the panel toggle group is hidden", async ({ page }) => {
+  const group = page.getByTestId("panel-toggle-group");
+  const count = await group.count();
+  if (count === 0) {
+    await expect(group).toHaveCount(0);
+    return;
+  }
+  await expect(group).toBeHidden();
+});

--- a/apps/web/src/lib/app-shell/Toolbar.svelte
+++ b/apps/web/src/lib/app-shell/Toolbar.svelte
@@ -16,8 +16,11 @@
     <div
       class="tooltip tooltip-bottom"
       data-tip={`Kelpie ${version}\nMarkdown to-do studio — edit, preview, and fine-tune your flow.`}
+      data-testid="toolbar-brand-tooltip"
     >
-      <span class="text-2xl font-black tracking-tight text-primary sm:text-3xl">Kelpie</span>
+      <span class="text-2xl font-black tracking-tight text-primary sm:text-3xl" data-testid="toolbar-brand-label">
+        Kelpie
+      </span>
     </div>
   </div>
 

--- a/specs/toolbar.spec.md
+++ b/specs/toolbar.spec.md
@@ -1,0 +1,135 @@
+# Toolbar Spec
+
+## Introduction
+
+The **Kelpie Toolbar** is the persistent header for the web app shell. It surfaces
+branding, exposes layout controls, and provides quick access to theming and save
+state information. The toolbar must stay visible, work across desktop and mobile
+layouts, and forward user intents to the shell stores that orchestrate the rest of
+the workspace.
+
+## Outcomes
+
+- **For users**:
+  - Always see where they are (brand + version) and the current save status.
+  - Switch between panels or view modes with one tap/click, even on mobile.
+  - Toggle themes without navigating away or digging into settings.
+- **For developers**:
+  - A single surface for wiring shell interactions (view mode, active panel,
+    theme, save state).
+  - Predictable composition of toolbar subcomponents with minimal layout logic
+    in the shell.
+
+## Goals
+
+- Keep toolbar visible (sticky) so save state and controls are always accessible.
+- Provide consistent affordances for switching panels (mobile) and view modes
+  (all breakpoints).
+- Surface save status prominently while remaining responsive in narrow layouts.
+- Expose theme toggle with contextual labels for accessibility.
+- Avoid duplicating shell state logic—delegate interactions to dedicated stores.
+
+## Scope
+
+**Included for MVP:**
+
+- Sticky, blurred header with brand, version tooltip, and responsive spacing.
+- Embedding of `PanelToggleGroup`, `SaveIndicator`, `ViewModeToggleButton`, and
+  `ThemeToggleButton` components.
+- Passing version string into branding tooltip copy.
+- Layout rules that keep controls grouped and right-aligned while allowing wrap
+  on narrow viewports.
+
+**Excluded for MVP:**
+
+- Contextual help / docs links.
+- Customization of toolbar contents via user settings.
+- Server-driven branding.
+
+## Structure
+
+- `<header>` wrapper uses a sticky position at the top with slight background
+  transparency and blur so content scrolls beneath it without losing contrast.
+- Left cluster: product name (“Kelpie”) with tooltip showing version and tagline.
+- Right cluster (`flex-1` container):
+  - `PanelToggleGroup` (renders only when layout is mobile via its own logic).
+  - `SaveIndicator` contained in a width-constrained wrapper for stability.
+  - `ViewModeToggleButton` for switching between editor/preview/settings modes.
+  - `ThemeToggleButton` for switching between light/dark themes.
+
+## Behavior
+
+- Branding tooltip concatenates the provided `version` prop with descriptive
+  copy; this tooltip appears on hover/focus via DaisyUI `tooltip` classes.
+- `PanelToggleGroup` subscribes to shell layout state and only renders controls
+  when mobile; toolbar always renders the component so desktop markup stays
+  consistent.
+- `SaveIndicator` is always visible; it adapts width for mobile vs. desktop and
+  reads from the persistence store to show status, timestamp, and tooltip.
+- `ViewModeToggleButton` updates shell view mode store; the toolbar does not
+  manage state beyond hosting the control.
+- `ThemeToggleButton` toggles theme store state and reflects the current mode via
+  icon swap and accessible label.
+- Controls are grouped with `flex` and `gap` utilities so they wrap neatly on
+  small screens while remaining right-aligned.
+
+## Accessibility
+
+- Header uses semantic `<header>` element and keeps interactive controls within
+  accessible buttons.
+- Branding tooltip content is available via `data-tip` and native `title`,
+  ensuring screen readers announce version and description when focused.
+- Save indicator uses `aria-live="polite"` and `role="status"` for updates,
+  enabling non-visual users to hear state changes without focus theft.
+- Toggle buttons expose `aria-label`, `aria-pressed`, and `role="group"` where
+  appropriate via their child components.
+
+## Assumptions
+
+- `version` prop is always a non-empty string supplied by the shell route.
+- Layout detection (desktop vs. mobile) is fully owned by shell stores and is
+  trustworthy when deciding whether `PanelToggleGroup` should show.
+- Theme store only supports two themes (light/dark) today; button labels reflect
+  that binary choice.
+
+## Future Improvements
+
+- Surface contextual help and onboarding links once the information architecture is ready.
+- Provide toolbar personalization so teams can pin additional controls without code changes.
+- Localize tooltip copy and control labels once i18n infrastructure lands.
+
+## Test Scenarios (Gherkin)
+
+```gherkin
+Feature: Toolbar interactions
+  The toolbar should keep key workspace controls available across devices.
+
+  Background:
+    Given I open the app with "basic.md"
+
+  Scenario: Branding tooltip communicates version and purpose
+    Then the toolbar brand tooltip contains "Kelpie 0.0.0-dev"
+    And the tooltip explains it is the markdown to-do studio
+
+  Scenario: Save indicator is always present
+    Then the toolbar displays the save indicator component
+    And the save indicator announces updates politely
+
+  Scenario: View mode switch updates shell state
+    When I choose the "Preview" view mode
+    Then the "Preview" panel should be visible
+    And the "Preview" view mode toggle is marked as active
+
+  Scenario: Theme toggle reflects current theme
+    Given the stored theme preference is cleared
+    When I toggle the theme from the toolbar
+    Then the document theme should be "dark"
+    And the theme toggle label reads "Switch to light theme"
+
+  Scenario: Panel toggle group only appears on mobile layouts
+    When I resize the viewport to "mobile"
+    Then the layout should be "mobile"
+    And the panel toggle group is visible within the toolbar
+    When I resize the viewport to "desktop"
+    Then the panel toggle group is hidden
+```


### PR DESCRIPTION
## Summary
- align the toolbar spec with current responsibilities, future improvements, and runnable scenarios
- expose toolbar brand test identifiers so automated checks can assert tooltip content
- add toolbar BDD feature coverage and supporting steps for branding, save indicator, view modes, theme toggle, and mobile panel controls

## Testing
- pnpm test:e2e *(fails: Playwright browser download blocked by 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68d6ff394e7c83299e17f0b4d97d7319