### PR TITLE
Add unit tests for app shell controls

### DIFF
--- a/apps/web/src/lib/app-shell/PanelToggleGroup.test.ts
+++ b/apps/web/src/lib/app-shell/PanelToggleGroup.test.ts
@@ -1,0 +1,89 @@
+import { render, screen, within } from "@testing-library/svelte";
+import userEvent from "@testing-library/user-event";
+import { tick } from "svelte";
+import { get } from "svelte/store";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import PanelToggleGroup from "./PanelToggleGroup.svelte";
+import { PANEL_ORDER, type PanelId } from "./contracts";
+import { activatePanel, setLayout, setViewMode, shellState } from "$lib/stores/shell";
+
+function panelLabel(panel: PanelId): string {
+  switch (panel) {
+    case "editor":
+      return "Editor";
+    case "preview":
+      return "Preview";
+    case "settings":
+      return "Settings";
+  }
+}
+
+describe("PanelToggleGroup", () => {
+  beforeEach(() => {
+    setLayout("desktop");
+    setViewMode("editor-preview");
+    activatePanel("editor");
+  });
+
+  afterEach(() => {
+    setLayout("desktop");
+    setViewMode("editor-preview");
+    activatePanel("editor");
+  });
+
+  it("does not render anything when the shell is in desktop layout", () => {
+    render(PanelToggleGroup);
+
+    expect(screen.queryByRole("group", { name: /Select active panel/i })).not.toBeInTheDocument();
+  });
+
+  it("shows an accessible toggle button for each panel when in mobile layout", () => {
+    setLayout("mobile");
+
+    render(PanelToggleGroup);
+
+    const group = screen.getByRole("group", { name: "Select active panel" });
+    const buttons = within(group).getAllByRole("button");
+    expect(buttons).toHaveLength(PANEL_ORDER.length);
+    const state = get(shellState);
+
+    for (const panel of PANEL_ORDER) {
+      const button = within(group).getByRole("button", { name: panelLabel(panel) });
+      expect(button).toBeVisible();
+      expect(button).toHaveAttribute("aria-pressed", String(state.activePanel === panel));
+    }
+  });
+
+  it("disables panels that are not allowed in the current view mode", () => {
+    setLayout("mobile");
+    setViewMode("settings");
+
+    render(PanelToggleGroup);
+
+    const editorButton = screen.getByRole("button", { name: "Editor" });
+    const previewButton = screen.getByRole("button", { name: "Preview" });
+    const settingsButton = screen.getByRole("button", { name: "Settings" });
+
+    expect(editorButton).toBeDisabled();
+    expect(previewButton).toBeDisabled();
+    expect(settingsButton).not.toBeDisabled();
+    expect(settingsButton).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("activates the selected panel when a button is clicked", async () => {
+    const user = userEvent.setup();
+    setLayout("mobile");
+
+    render(PanelToggleGroup);
+
+    const previewButton = screen.getByRole("button", { name: "Preview" });
+    const editorButton = screen.getByRole("button", { name: "Editor" });
+
+    await user.click(previewButton);
+    await tick();
+
+    expect(previewButton).toHaveAttribute("aria-pressed", "true");
+    expect(editorButton).toHaveAttribute("aria-pressed", "false");
+    expect(get(shellState).activePanel).toBe("preview");
+  });
+});

--- a/apps/web/src/lib/app-shell/ThemeToggleButton.test.ts
+++ b/apps/web/src/lib/app-shell/ThemeToggleButton.test.ts
@@ -1,0 +1,65 @@
+import { render, screen } from "@testing-library/svelte";
+import userEvent from "@testing-library/user-event";
+import { tick } from "svelte";
+import { get } from "svelte/store";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+type ThemeName = "light" | "dark";
+
+const themeMocks = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { writable } = require("svelte/store") as typeof import("svelte/store");
+  const theme = writable<ThemeName>("light");
+  const toggleTheme = vi.fn(() => theme.update((value) => (value === "light" ? "dark" : "light")));
+  return { theme, toggleTheme };
+});
+
+vi.mock("$lib/stores/theme", () => themeMocks);
+
+import ThemeToggleButton from "./ThemeToggleButton.svelte";
+import { theme, toggleTheme } from "$lib/stores/theme";
+
+const toggleThemeMock = toggleTheme as ReturnType<typeof vi.fn>;
+
+describe("ThemeToggleButton", () => {
+  beforeEach(async () => {
+    toggleThemeMock.mockClear();
+    theme.set("light");
+    await tick();
+  });
+
+  afterEach(async () => {
+    theme.set("light");
+    await tick();
+  });
+
+  it("labels the control based on the currently active theme", () => {
+    render(ThemeToggleButton);
+
+    const button = screen.getByRole("button", { name: "Switch to dark theme" });
+    expect(button).toBeInTheDocument();
+    expect(get(theme)).toBe("light");
+  });
+
+  it("invokes the toggle handler when clicked", async () => {
+    const user = userEvent.setup();
+    render(ThemeToggleButton);
+
+    const button = screen.getByRole("button", { name: "Switch to dark theme" });
+
+    await user.click(button);
+    await tick();
+
+    expect(toggleThemeMock).toHaveBeenCalledTimes(1);
+    expect(get(theme)).toBe("dark");
+  });
+
+  it("uses the dark-theme label when the store is pre-set", async () => {
+    theme.set("dark");
+    await tick();
+
+    render(ThemeToggleButton);
+
+    expect(screen.getByRole("button", { name: "Switch to light theme" })).toBeVisible();
+  });
+});

--- a/apps/web/src/lib/app-shell/ViewModeToggleButton.test.ts
+++ b/apps/web/src/lib/app-shell/ViewModeToggleButton.test.ts
@@ -1,0 +1,70 @@
+import { render, screen, within } from "@testing-library/svelte";
+import userEvent from "@testing-library/user-event";
+import { tick } from "svelte";
+import { get } from "svelte/store";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import ViewModeToggleButton from "./ViewModeToggleButton.svelte";
+import type { ViewMode } from "./contracts";
+import { setLayout, setViewMode, shellState } from "$lib/stores/shell";
+
+type ModeExpectation = { id: ViewMode; label: string };
+
+const modes: ModeExpectation[] = [
+  { id: "editor-preview", label: "Editor & preview" },
+  { id: "preview-only", label: "Preview" },
+  { id: "settings", label: "Settings" }
+];
+
+describe("ViewModeToggleButton", () => {
+  beforeEach(() => {
+    setLayout("desktop");
+    setViewMode("editor-preview");
+  });
+
+  afterEach(() => {
+    setLayout("desktop");
+    setViewMode("editor-preview");
+  });
+
+  it("renders an accessible toggle for each view mode", () => {
+    render(ViewModeToggleButton);
+
+    const group = screen.getByRole("group", { name: "Select workspace mode" });
+    const buttons = within(group).getAllByRole("button");
+    expect(buttons).toHaveLength(modes.length);
+    const state = get(shellState);
+
+    for (const mode of modes) {
+      const button = within(group).getByRole("button", { name: mode.label });
+      expect(button).toHaveAttribute("aria-pressed", String(state.viewMode === mode.id));
+    }
+  });
+
+  it("updates the shell state when a different mode is selected", async () => {
+    const user = userEvent.setup();
+    render(ViewModeToggleButton);
+
+    const previewButton = screen.getByRole("button", { name: "Preview" });
+
+    await user.click(previewButton);
+    await tick();
+
+    const state = get(shellState);
+    expect(state.viewMode).toBe("preview-only");
+    expect(state.activePanel).toBe("preview");
+    expect(previewButton).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("reflects external view mode changes", async () => {
+    render(ViewModeToggleButton);
+
+    setViewMode("settings");
+    await tick();
+
+    const settingsButton = screen.getByRole("button", { name: "Settings" });
+    const previewButton = screen.getByRole("button", { name: "Preview" });
+
+    expect(settingsButton).toHaveAttribute("aria-pressed", "true");
+    expect(previewButton).toHaveAttribute("aria-pressed", "false");
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for the mobile panel toggle group to cover accessibility, disable states, and activation
- verify the view mode toggle updates shell state and reflects external changes
- mock the theme store to confirm the theme toggle button labeling and behavior

## Testing
- pnpm --filter web test:unit -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d6fc4fd66c8329966f43c59ef0ed2b