### PR TITLE
Remove unused panelIsActive helper

### DIFF
--- a/apps/web/src/lib/app-shell/AppShell.svelte
+++ b/apps/web/src/lib/app-shell/AppShell.svelte
@@ -37,14 +37,6 @@
     return "app-shell__panel app-shell__panel--stacked";
   }
 
-  function panelIsActive(panel: PanelDefinition): boolean {
-    if (layout === "desktop") {
-      return true;
-    }
-
-    return panel.id === activePanel;
-  }
-
   function panelIsHidden(panel: PanelDefinition): boolean {
     if (layout === "desktop") {
       return false;


### PR DESCRIPTION
## Summary
- remove the unused `panelIsActive` helper in the app shell to satisfy eslint

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d7006268f0832998beb229baac0cc0