### PR TITLE
Refine toolbar branding structure for maintainability

### DIFF
--- a/apps/web/src/lib/app-shell/Toolbar.svelte
+++ b/apps/web/src/lib/app-shell/Toolbar.svelte
@@ -1,9 +1,10 @@
 <svelte:options runes={false} />
 
 <script lang="ts">
-  import SaveIndicator from "./SaveIndicator.svelte";
   import PanelToggleGroup from "./PanelToggleGroup.svelte";
+  import SaveIndicator from "./SaveIndicator.svelte";
   import ThemeToggleButton from "./ThemeToggleButton.svelte";
+  import ToolbarBrand from "./ToolbarBrand.svelte";
   import ViewModeToggleButton from "./ViewModeToggleButton.svelte";
 
   export let version: string;
@@ -13,15 +14,7 @@
   class="sticky top-0 z-30 flex w-full flex-wrap items-center justify-between gap-3 border-b border-base-300/70 bg-base-100/95 px-3 py-2 backdrop-blur"
 >
   <div class="flex items-center gap-3">
-    <div
-      class="tooltip tooltip-bottom"
-      data-tip={`Kelpie ${version}\nMarkdown to-do studio — edit, preview, and fine-tune your flow.`}
-      data-testid="toolbar-brand-tooltip"
-    >
-      <span class="text-2xl font-black tracking-tight text-primary sm:text-3xl" data-testid="toolbar-brand-label">
-        Kelpie
-      </span>
-    </div>
+    <ToolbarBrand {version} />
   </div>
 
   <div class="flex flex-1 flex-wrap items-center justify-end gap-3 sm:gap-4">

--- a/apps/web/src/lib/app-shell/ToolbarBrand.svelte
+++ b/apps/web/src/lib/app-shell/ToolbarBrand.svelte
@@ -1,0 +1,15 @@
+<svelte:options runes={false} />
+
+<script lang="ts">
+  import { BRAND_NAME, buildBrandTooltip } from "./toolbar.constants";
+
+  export let version: string;
+
+  $: tooltipCopy = buildBrandTooltip(version);
+</script>
+
+<div class="tooltip tooltip-bottom" data-tip={tooltipCopy} title={tooltipCopy} data-testid="toolbar-brand-tooltip">
+  <span class="text-2xl font-black tracking-tight text-primary sm:text-3xl" data-testid="toolbar-brand-label">
+    {BRAND_NAME}
+  </span>
+</div>

--- a/apps/web/src/lib/app-shell/toolbar.constants.ts
+++ b/apps/web/src/lib/app-shell/toolbar.constants.ts
@@ -1,0 +1,7 @@
+export const BRAND_NAME = "Kelpie";
+export const BRAND_TAGLINE = "Markdown to-do studio — edit, preview, and fine-tune your flow.";
+
+export function buildBrandTooltip(version: string): string {
+  const versionLabel = version.trim() || "Unknown";
+  return `${BRAND_NAME} ${versionLabel}\n${BRAND_TAGLINE}`;
+}

--- a/specs/toolbar.spec.md
+++ b/specs/toolbar.spec.md
@@ -50,7 +50,8 @@ the workspace.
 
 - `<header>` wrapper uses a sticky position at the top with slight background
   transparency and blur so content scrolls beneath it without losing contrast.
-- Left cluster: product name (“Kelpie”) with tooltip showing version and tagline.
+- Left cluster renders the `ToolbarBrand` subcomponent which encapsulates all
+  branding copy, tooltip composition, and typography styles.
 - Right cluster (`flex-1` container):
   - `PanelToggleGroup` (renders only when layout is mobile via its own logic).
   - `SaveIndicator` contained in a width-constrained wrapper for stability.
@@ -59,8 +60,11 @@ the workspace.
 
 ## Behavior
 
-- Branding tooltip concatenates the provided `version` prop with descriptive
-  copy; this tooltip appears on hover/focus via DaisyUI `tooltip` classes.
+- Branding tooltip is derived by `ToolbarBrand` via the shared
+  `buildBrandTooltip(version)` helper which trims input and falls back to
+  "Unknown" when the string is empty. The tooltip appears on hover/focus via
+  DaisyUI `tooltip` classes and is duplicated in the `title` attribute for
+  accessibility.
 - `PanelToggleGroup` subscribes to shell layout state and only renders controls
   when mobile; toolbar always renders the component so desktop markup stays
   consistent.
@@ -77,8 +81,8 @@ the workspace.
 
 - Header uses semantic `<header>` element and keeps interactive controls within
   accessible buttons.
-- Branding tooltip content is available via `data-tip` and native `title`,
-  ensuring screen readers announce version and description when focused.
+- `ToolbarBrand` duplicates tooltip content in both `data-tip` and `title`
+  attributes so screen readers announce version and description when focused.
 - Save indicator uses `aria-live="polite"` and `role="status"` for updates,
   enabling non-visual users to hear state changes without focus theft.
 - Toggle buttons expose `aria-label`, `aria-pressed`, and `role="group"` where
@@ -86,7 +90,8 @@ the workspace.
 
 ## Assumptions
 
-- `version` prop is always a non-empty string supplied by the shell route.
+- `version` prop is supplied by the shell route and may occasionally be empty;
+  `ToolbarBrand` guards against blanks when generating tooltip text.
 - Layout detection (desktop vs. mobile) is fully owned by shell stores and is
   trustworthy when deciding whether `PanelToggleGroup` should show.
 - Theme store only supports two themes (light/dark) today; button labels reflect
@@ -97,6 +102,17 @@ the workspace.
 - Surface contextual help and onboarding links once the information architecture is ready.
 - Provide toolbar personalization so teams can pin additional controls without code changes.
 - Localize tooltip copy and control labels once i18n infrastructure lands.
+
+## Maintainability Considerations
+
+- Shared constants keep branding strings in `toolbar.constants.ts` so copy edits
+  land in one place and Svelte components stay focused on layout concerns.
+- `ToolbarBrand` isolates tooltip formatting logic, ensuring downstream
+  refactors or localization can swap implementations without touching
+  `Toolbar.svelte`.
+- Toolbar composition favors declarative stacking of imported components instead
+  of inline helpers, so future additions (e.g., help menus) can be inserted by
+  adding one more component import.
 
 ## Test Scenarios (Gherkin)
 


### PR DESCRIPTION
## Summary
- extract the toolbar brand presentation into a dedicated `ToolbarBrand` component that handles tooltip composition
- centralize brand name, tagline, and tooltip builder in a shared constants module for easier future edits
- refresh the toolbar specification to document the new component structure, behavior safeguards, and maintainability considerations

## Testing
- pnpm --filter web format
- pnpm --filter web lint *(fails: existing unused-variable errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d70389a7588329b2b2b08f0d23f861