### PR TITLE
Use enums for UI theme and preview modes

### DIFF
--- a/apps/web/src/lib/app-shell/ThemeToggleButton.svelte
+++ b/apps/web/src/lib/app-shell/ThemeToggleButton.svelte
@@ -1,10 +1,10 @@
 <svelte:options runes={false} />
 
 <script lang="ts">
-  import { theme, toggleTheme } from "$lib/stores/theme";
+  import { Theme, theme, toggleTheme } from "$lib/stores/theme";
 
   function nextThemeLabel(): string {
-    return $theme === "light" ? "Switch to dark theme" : "Switch to light theme";
+    return $theme === Theme.Light ? "Switch to dark theme" : "Switch to light theme";
   }
 </script>
 
@@ -15,7 +15,7 @@
   aria-label={nextThemeLabel()}
   title={nextThemeLabel()}
 >
-  {#if $theme === "light"}
+  {#if $theme === Theme.Light}
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" class="h-4 w-4">
       <circle cx="12" cy="12" r="4" stroke-width="1.5" />
       <path

--- a/apps/web/src/lib/panels/preview/InteractivePreviewPanel.svelte
+++ b/apps/web/src/lib/panels/preview/InteractivePreviewPanel.svelte
@@ -10,12 +10,16 @@
   export let tasks: Task[] = [];
   export let content = "";
 
-  type ViewMode = "tasks" | "markdown";
-  let view: ViewMode = "tasks";
+  enum ViewMode {
+    Tasks = "tasks",
+    Markdown = "markdown"
+  }
+
+  let view: ViewMode = ViewMode.Tasks;
 
   const tabs: Array<{ id: ViewMode; label: string; description: string }> = [
-    { id: "tasks", label: "Tasks", description: "View parsed tasks" },
-    { id: "markdown", label: "Document", description: "View rendered Markdown" }
+    { id: ViewMode.Tasks, label: "Tasks", description: "View parsed tasks" },
+    { id: ViewMode.Markdown, label: "Document", description: "View rendered Markdown" }
   ];
 
   $: markdownHtml = renderMarkdown(content);
@@ -68,7 +72,7 @@
     </nav>
   </header>
 
-  {#if view === "tasks"}
+  {#if view === ViewMode.Tasks}
     {#if tasks.length === 0}
       <div class="flex flex-1 items-center justify-center px-6" data-testid="tasks-empty-state">
         <p

--- a/apps/web/src/lib/stores/theme.test.ts
+++ b/apps/web/src/lib/stores/theme.test.ts
@@ -17,14 +17,14 @@ describe("theme store", () => {
     const setAttributeSpy = vi.spyOn(document.documentElement, "setAttribute");
     const setItemSpy = vi.spyOn(Storage.prototype, "setItem");
 
-    const { theme, toggleTheme } = await import("./theme");
+    const { Theme, theme, toggleTheme } = await import("./theme");
 
-    expect(get(theme)).toBe("light");
+    expect(get(theme)).toBe(Theme.Light);
     expect(setAttributeSpy).not.toHaveBeenCalled();
     expect(setItemSpy).not.toHaveBeenCalled();
 
     toggleTheme();
-    expect(get(theme)).toBe("dark");
+    expect(get(theme)).toBe(Theme.Dark);
     expect(setAttributeSpy).not.toHaveBeenCalled();
     expect(setItemSpy).not.toHaveBeenCalled();
 
@@ -39,17 +39,17 @@ describe("theme store", () => {
     const setAttributeSpy = vi.spyOn(document.documentElement, "setAttribute");
     const setItemSpy = vi.spyOn(Storage.prototype, "setItem");
 
-    const { theme, toggleTheme } = await import("./theme");
+    const { Theme, theme, toggleTheme } = await import("./theme");
 
-    expect(get(theme)).toBe("dark");
-    expect(setAttributeSpy).toHaveBeenCalledWith("data-theme", "dark");
-    expect(setItemSpy).toHaveBeenCalledWith(THEME_STORAGE_KEY, "dark");
+    expect(get(theme)).toBe(Theme.Dark);
+    expect(setAttributeSpy).toHaveBeenCalledWith("data-theme", Theme.Dark);
+    expect(setItemSpy).toHaveBeenCalledWith(THEME_STORAGE_KEY, Theme.Dark);
 
     toggleTheme();
 
-    expect(get(theme)).toBe("light");
-    expect(setAttributeSpy).toHaveBeenLastCalledWith("data-theme", "light");
-    expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe("light");
+    expect(get(theme)).toBe(Theme.Light);
+    expect(setAttributeSpy).toHaveBeenLastCalledWith("data-theme", Theme.Light);
+    expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe(Theme.Light);
 
     setAttributeSpy.mockRestore();
     setItemSpy.mockRestore();
@@ -59,8 +59,8 @@ describe("theme store", () => {
     vi.doMock("$app/environment", () => ({ browser: true }));
     localStorage.setItem(THEME_STORAGE_KEY, "sepia");
 
-    const { theme } = await import("./theme");
+    const { Theme, theme } = await import("./theme");
 
-    expect(get(theme)).toBe("light");
+    expect(get(theme)).toBe(Theme.Light);
   });
 });

--- a/apps/web/src/lib/stores/theme.ts
+++ b/apps/web/src/lib/stores/theme.ts
@@ -1,17 +1,20 @@
 import { browser } from "$app/environment";
 import { writable } from "svelte/store";
 
-export type ThemeName = "light" | "dark";
+export enum Theme {
+  Light = "light",
+  Dark = "dark"
+}
 
 const STORAGE_KEY = "kelpie-theme";
 
-function getInitialTheme(): ThemeName {
-  if (!browser) return "light";
+function getInitialTheme(): Theme {
+  if (!browser) return Theme.Light;
   const stored = localStorage.getItem(STORAGE_KEY);
-  return stored === "dark" ? "dark" : "light";
+  return stored === Theme.Dark ? Theme.Dark : Theme.Light;
 }
 
-const themeStore = writable<ThemeName>(getInitialTheme());
+const themeStore = writable<Theme>(getInitialTheme());
 
 if (browser) {
   themeStore.subscribe((value) => {
@@ -23,5 +26,5 @@ if (browser) {
 export const theme = themeStore;
 
 export function toggleTheme(): void {
-  themeStore.update((current) => (current === "light" ? "dark" : "light"));
+  themeStore.update((current) => (current === Theme.Light ? Theme.Dark : Theme.Light));
 }


### PR DESCRIPTION
## Summary
- replace the theme string literals with a `Theme` enum and propagate the change through the toggle button
- switch the interactive preview panel tab state to a `ViewMode` enum for clarity
- update the associated unit tests to exercise the new enums and keep mocks aligned

## Testing
- pnpm --filter web exec vitest run src/lib/app-shell/ThemeToggleButton.test.ts src/lib/stores/theme.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d705ac6ea083298f34277572b62b89