### PR TITLE
Add resilient UI component tests

### DIFF
--- a/apps/web/src/lib/app-shell/DockToggleButton.test.ts
+++ b/apps/web/src/lib/app-shell/DockToggleButton.test.ts
@@ -1,0 +1,72 @@
+import { render, screen } from "@testing-library/svelte";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const dockClassesMock = vi.hoisted(() => ({
+  getDockButtonClasses: vi.fn(() => "mocked-dock-classes")
+}));
+
+vi.mock("./dockButtonClasses", () => dockClassesMock);
+
+import DockToggleButton from "./DockToggleButton.svelte";
+import DockToggleButtonHarness from "./DockToggleButtonHarness.svelte";
+import { getDockButtonClasses } from "./dockButtonClasses";
+
+const getDockButtonClassesMock = vi.mocked(getDockButtonClasses);
+
+describe("DockToggleButton", () => {
+  beforeEach(() => {
+    getDockButtonClassesMock.mockClear();
+  });
+
+  it("applies computed classes and accessibility attributes", () => {
+    render(DockToggleButton, {
+      props: {
+        id: "preview",
+        label: "Preview panel",
+        tone: "secondary",
+        isActive: true,
+        isDisabled: true,
+        ariaLabel: "Preview panel button",
+        title: "Switch to preview"
+      }
+    });
+
+    const button = screen.getByRole("button", { name: "Preview panel button" });
+
+    expect(button).toBeDisabled();
+    expect(button).toHaveAttribute("aria-pressed", "true");
+    expect(button).toHaveAttribute("title", "Switch to preview");
+    expect(button.className).toBe("mocked-dock-classes");
+    expect(getDockButtonClassesMock).toHaveBeenCalledWith({
+      tone: "secondary",
+      isActive: true,
+      disabled: true
+    });
+  });
+
+  it("dispatches a select event with the button identifier", async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+
+    render(DockToggleButtonHarness, {
+      props: {
+        id: "editor",
+        label: "Editor",
+        tone: "primary",
+        isActive: false,
+        onSelect
+      }
+    });
+
+    const button = screen.getByRole("button", { name: "Editor" });
+    await user.click(button);
+
+    expect(onSelect).toHaveBeenCalledWith("editor");
+    expect(getDockButtonClassesMock).toHaveBeenCalledWith({
+      tone: "primary",
+      isActive: false,
+      disabled: false
+    });
+  });
+});

--- a/apps/web/src/lib/app-shell/DockToggleButtonHarness.svelte
+++ b/apps/web/src/lib/app-shell/DockToggleButtonHarness.svelte
@@ -1,0 +1,33 @@
+<svelte:options runes={false} />
+
+<script lang="ts">
+  import DockToggleButton from "./DockToggleButton.svelte";
+  import type { DockButtonTone } from "./dockButtonClasses";
+
+  export let id: string;
+  export let label: string;
+  export let tone: DockButtonTone = "primary";
+  export let isActive = false;
+  export let isDisabled = false;
+  export let ariaLabel: string | undefined = undefined;
+  export let title: string | undefined = undefined;
+  export let onSelect: (detail: string) => void = () => {};
+
+  function handleSelect(event: CustomEvent<string>) {
+    onSelect(event.detail);
+  }
+</script>
+
+<DockToggleButton
+  {id}
+  {label}
+  {tone}
+  {isActive}
+  {isDisabled}
+  {ariaLabel}
+  {title}
+  on:select={handleSelect}
+  {...$$restProps}
+>
+  <slot />
+</DockToggleButton>

--- a/apps/web/src/lib/app-shell/PanelToggleGroup.test.ts
+++ b/apps/web/src/lib/app-shell/PanelToggleGroup.test.ts
@@ -4,18 +4,18 @@ import { tick } from "svelte";
 import { get } from "svelte/store";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import PanelToggleGroup from "./PanelToggleGroup.svelte";
-import { PANEL_ORDER, type PanelId } from "./contracts";
+import { type PanelId } from "./contracts";
+import { PANEL_DEFINITIONS } from "./panels";
 import { activatePanel, setLayout, setViewMode, shellState } from "$lib/stores/shell";
 
+const PANEL_METADATA = PANEL_DEFINITIONS.map(({ id, label }) => ({ id, label })) satisfies {
+  id: PanelId;
+  label: string;
+}[];
+
 function panelLabel(panel: PanelId): string {
-  switch (panel) {
-    case "editor":
-      return "Editor";
-    case "preview":
-      return "Preview";
-    case "settings":
-      return "Settings";
-  }
+  const match = PANEL_METADATA.find((definition) => definition.id === panel);
+  return match?.label ?? panel;
 }
 
 describe("PanelToggleGroup", () => {
@@ -44,13 +44,13 @@ describe("PanelToggleGroup", () => {
 
     const group = screen.getByRole("group", { name: "Select active panel" });
     const buttons = within(group).getAllByRole("button");
-    expect(buttons).toHaveLength(PANEL_ORDER.length);
+    expect(buttons).toHaveLength(PANEL_METADATA.length);
     const state = get(shellState);
 
-    for (const panel of PANEL_ORDER) {
-      const button = within(group).getByRole("button", { name: panelLabel(panel) });
+    for (const { id } of PANEL_METADATA) {
+      const button = within(group).getByRole("button", { name: panelLabel(id) });
       expect(button).toBeVisible();
-      expect(button).toHaveAttribute("aria-pressed", String(state.activePanel === panel));
+      expect(button).toHaveAttribute("aria-pressed", String(state.activePanel === id));
     }
   });
 
@@ -60,9 +60,9 @@ describe("PanelToggleGroup", () => {
 
     render(PanelToggleGroup);
 
-    const editorButton = screen.getByRole("button", { name: "Editor" });
-    const previewButton = screen.getByRole("button", { name: "Preview" });
-    const settingsButton = screen.getByRole("button", { name: "Settings" });
+    const editorButton = screen.getByRole("button", { name: panelLabel("editor") });
+    const previewButton = screen.getByRole("button", { name: panelLabel("preview") });
+    const settingsButton = screen.getByRole("button", { name: panelLabel("settings") });
 
     expect(editorButton).toBeDisabled();
     expect(previewButton).toBeDisabled();
@@ -76,8 +76,8 @@ describe("PanelToggleGroup", () => {
 
     render(PanelToggleGroup);
 
-    const previewButton = screen.getByRole("button", { name: "Preview" });
-    const editorButton = screen.getByRole("button", { name: "Editor" });
+    const previewButton = screen.getByRole("button", { name: panelLabel("preview") });
+    const editorButton = screen.getByRole("button", { name: panelLabel("editor") });
 
     await user.click(previewButton);
     await tick();

--- a/apps/web/src/lib/app-shell/Toolbar.test.ts
+++ b/apps/web/src/lib/app-shell/Toolbar.test.ts
@@ -1,0 +1,56 @@
+import { render, screen } from "@testing-library/svelte";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import Toolbar from "./Toolbar.svelte";
+import { PANEL_DEFINITIONS } from "./panels";
+import { ViewMode } from "./contracts";
+import { activatePanel, setLayout, setViewMode } from "$lib/stores/shell";
+import { resetSaveStatus } from "$lib/stores/persistence";
+
+describe("Toolbar", () => {
+  beforeEach(() => {
+    setLayout("desktop");
+    setViewMode(ViewMode.EditorPreview);
+    activatePanel("editor");
+    resetSaveStatus();
+  });
+
+  afterEach(() => {
+    setLayout("desktop");
+    setViewMode(ViewMode.EditorPreview);
+    activatePanel("editor");
+    resetSaveStatus();
+  });
+
+  it("renders a branded tooltip that includes the app version", () => {
+    const version = "1.2.3";
+
+    render(Toolbar, { version });
+
+    const tooltip = screen.getByTestId("toolbar-brand-tooltip");
+    expect(tooltip).toHaveAttribute("data-tip", expect.stringContaining(version));
+    expect(screen.getByTestId("toolbar-brand-label")).toHaveTextContent("Kelpie");
+  });
+
+  it("exposes panel toggles, save status, view mode controls, and theme switcher", () => {
+    setLayout("mobile");
+
+    render(Toolbar, { version: "2.0.0" });
+
+    const panelGroup = screen.getByTestId("panel-toggle-group");
+    expect(panelGroup).toBeVisible();
+    for (const panel of PANEL_DEFINITIONS) {
+      expect(screen.getByTestId(`panel-toggle-${panel.id}`)).toBeInTheDocument();
+    }
+
+    expect(screen.getByTestId("save-indicator")).toBeVisible();
+
+    const viewModeGroup = screen.getByRole("group", { name: "Select workspace mode" });
+    expect(viewModeGroup).toBeVisible();
+    for (const mode of Object.values(ViewMode)) {
+      expect(screen.getByTestId(`view-mode-${mode}`)).toBeInTheDocument();
+    }
+
+    expect(screen.getByRole("button", { name: /Switch to (dark|light) theme/i })).toBeVisible();
+  });
+});

--- a/apps/web/src/lib/app-shell/ViewModeToggleButton.svelte
+++ b/apps/web/src/lib/app-shell/ViewModeToggleButton.svelte
@@ -5,10 +5,8 @@
   import SettingsIcon from "$lib/components/icons/SettingsIcon.svelte";
   import SplitViewIcon from "$lib/components/icons/SplitViewIcon.svelte";
   import { setViewMode, shellState } from "$lib/stores/shell";
-  import type { ViewMode } from "./contracts";
   import DockToggleButton from "./DockToggleButton.svelte";
   import { ViewMode } from "./contracts";
-  import { getDockButtonClasses } from "./dockButtonClasses";
 
   const viewOptions: { id: ViewMode; label: string; Icon: typeof SplitViewIcon }[] = [
     { id: ViewMode.EditorPreview, label: "Editor & preview", Icon: SplitViewIcon },


### PR DESCRIPTION
## Summary
- add targeted unit tests for DockToggleButton and a lightweight harness to capture select events without depending on styling details
- add a toolbar regression test covering the brand tooltip and key controls, and derive PanelToggleGroup expectations from the shared panel metadata
- tidy the view mode toggle component imports after removing the unused type-only import

## Testing
- pnpm --filter web test:unit -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d70417b4708329ace864f75837f547