### PR TITLE
Refine toolbar layout constants and add toolbar tests

### DIFF
--- a/apps/web/src/lib/app-shell/PanelToggleGroup.svelte
+++ b/apps/web/src/lib/app-shell/PanelToggleGroup.svelte
@@ -3,8 +3,6 @@
 <script lang="ts">
   import { activatePanel, shellState } from "$lib/stores/shell";
   import { PanelId, ShellLayout, isPanelAllowedInMode } from "./contracts";
-  import { getDockButtonClasses, type DockButtonTone } from "./dockButtonClasses";
-  import { type PanelId, isPanelAllowedInMode } from "./contracts";
   import DockToggleButton from "./DockToggleButton.svelte";
   import { type DockButtonTone } from "./dockButtonClasses";
   import { PANEL_DEFINITIONS } from "./panels";

--- a/apps/web/src/lib/app-shell/PanelToggleGroup.test.ts
+++ b/apps/web/src/lib/app-shell/PanelToggleGroup.test.ts
@@ -4,18 +4,14 @@ import { tick } from "svelte";
 import { get } from "svelte/store";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import PanelToggleGroup from "./PanelToggleGroup.svelte";
-import { PANEL_ORDER, type PanelId } from "./contracts";
+import { PanelId } from "./contracts";
+import { PANEL_DEFINITIONS, PANEL_LABELS } from "./panels";
 import { activatePanel, setLayout, setViewMode, shellState } from "$lib/stores/shell";
 
+const PANEL_ORDER = PANEL_DEFINITIONS.map((panel) => panel.id);
+
 function panelLabel(panel: PanelId): string {
-  switch (panel) {
-    case "editor":
-      return "Editor";
-    case "preview":
-      return "Preview";
-    case "settings":
-      return "Settings";
-  }
+  return PANEL_LABELS[panel];
 }
 
 describe("PanelToggleGroup", () => {
@@ -60,9 +56,9 @@ describe("PanelToggleGroup", () => {
 
     render(PanelToggleGroup);
 
-    const editorButton = screen.getByRole("button", { name: "Editor" });
-    const previewButton = screen.getByRole("button", { name: "Preview" });
-    const settingsButton = screen.getByRole("button", { name: "Settings" });
+    const editorButton = screen.getByRole("button", { name: panelLabel(PanelId.Editor) });
+    const previewButton = screen.getByRole("button", { name: panelLabel(PanelId.Preview) });
+    const settingsButton = screen.getByRole("button", { name: panelLabel(PanelId.Settings) });
 
     expect(editorButton).toBeDisabled();
     expect(previewButton).toBeDisabled();
@@ -76,8 +72,8 @@ describe("PanelToggleGroup", () => {
 
     render(PanelToggleGroup);
 
-    const previewButton = screen.getByRole("button", { name: "Preview" });
-    const editorButton = screen.getByRole("button", { name: "Editor" });
+    const previewButton = screen.getByRole("button", { name: panelLabel(PanelId.Preview) });
+    const editorButton = screen.getByRole("button", { name: panelLabel(PanelId.Editor) });
 
     await user.click(previewButton);
     await tick();

--- a/apps/web/src/lib/app-shell/Toolbar.svelte
+++ b/apps/web/src/lib/app-shell/Toolbar.svelte
@@ -6,21 +6,26 @@
   import ThemeToggleButton from "./ThemeToggleButton.svelte";
   import ToolbarBrand from "./ToolbarBrand.svelte";
   import ViewModeToggleButton from "./ViewModeToggleButton.svelte";
+  import {
+    TOOLBAR_BRAND_CLUSTER_CLASSES,
+    TOOLBAR_CONTROLS_CLUSTER_CLASSES,
+    TOOLBAR_SAVE_INDICATOR_WRAPPER_CLASSES,
+    TOOLBAR_TEST_IDS,
+    TOOLBAR_WRAPPER_CLASSES
+  } from "./toolbar.constants";
 
   export let version: string;
 </script>
 
-<header
-  class="sticky top-0 z-30 flex w-full flex-wrap items-center justify-between gap-3 border-b border-base-300/70 bg-base-100/95 px-3 py-2 backdrop-blur"
->
-  <div class="flex items-center gap-3">
+<header class={TOOLBAR_WRAPPER_CLASSES} data-testid={TOOLBAR_TEST_IDS.root}>
+  <div class={TOOLBAR_BRAND_CLUSTER_CLASSES} data-testid={TOOLBAR_TEST_IDS.brandCluster}>
     <ToolbarBrand {version} />
   </div>
 
-  <div class="flex flex-1 flex-wrap items-center justify-end gap-3 sm:gap-4">
+  <div class={TOOLBAR_CONTROLS_CLUSTER_CLASSES} data-testid={TOOLBAR_TEST_IDS.controlsCluster}>
     <PanelToggleGroup />
 
-    <div class="sm:w-auto">
+    <div class={TOOLBAR_SAVE_INDICATOR_WRAPPER_CLASSES} data-testid={TOOLBAR_TEST_IDS.saveIndicatorWrapper}>
       <SaveIndicator />
     </div>
 

--- a/apps/web/src/lib/app-shell/Toolbar.test.ts
+++ b/apps/web/src/lib/app-shell/Toolbar.test.ts
@@ -1,0 +1,53 @@
+import { render, screen, within } from "@testing-library/svelte";
+import { describe, expect, it } from "vitest";
+import Toolbar from "./Toolbar.svelte";
+import {
+  BRAND_NAME,
+  BRAND_TAGLINE,
+  TOOLBAR_BRAND_CLUSTER_CLASSES,
+  TOOLBAR_CONTROLS_CLUSTER_CLASSES,
+  TOOLBAR_SAVE_INDICATOR_WRAPPER_CLASSES,
+  TOOLBAR_TEST_IDS,
+  TOOLBAR_WRAPPER_CLASSES,
+  buildBrandTooltip
+} from "./toolbar.constants";
+
+function expectElementToHaveClasses(element: HTMLElement, classes: string): void {
+  expect(element).toHaveClass(...classes.split(" "));
+}
+
+describe("Toolbar", () => {
+  it("renders the toolbar layout with stable clusters and controls", () => {
+    render(Toolbar, { version: "0.0.0-dev" });
+
+    const toolbar = screen.getByTestId(TOOLBAR_TEST_IDS.root);
+    expect(toolbar).toBeVisible();
+    expectElementToHaveClasses(toolbar, TOOLBAR_WRAPPER_CLASSES);
+
+    const brandCluster = screen.getByTestId(TOOLBAR_TEST_IDS.brandCluster);
+    expectElementToHaveClasses(brandCluster, TOOLBAR_BRAND_CLUSTER_CLASSES);
+    const brandLabel = within(brandCluster).getByTestId("toolbar-brand-label");
+    expect(brandLabel).toHaveTextContent(BRAND_NAME);
+
+    const controlsCluster = screen.getByTestId(TOOLBAR_TEST_IDS.controlsCluster);
+    expectElementToHaveClasses(controlsCluster, TOOLBAR_CONTROLS_CLUSTER_CLASSES);
+
+    const saveIndicatorWrapper = screen.getByTestId(TOOLBAR_TEST_IDS.saveIndicatorWrapper);
+    expectElementToHaveClasses(saveIndicatorWrapper, TOOLBAR_SAVE_INDICATOR_WRAPPER_CLASSES);
+    expect(saveIndicatorWrapper).toContainElement(screen.getByTestId("save-indicator"));
+
+    expect(screen.getByRole("group", { name: "Select workspace mode" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Switch to dark theme" })).toBeVisible();
+    expect(screen.queryByTestId("panel-toggle-group")).not.toBeInTheDocument();
+  });
+
+  it("builds the brand tooltip from a trimmed version string", () => {
+    render(Toolbar, { version: "  1.2.3 " });
+
+    const tooltip = screen.getByTestId("toolbar-brand-tooltip");
+    expect(tooltip).toHaveAttribute("title", buildBrandTooltip("1.2.3"));
+    expect(tooltip).toHaveAttribute("data-tip", buildBrandTooltip("1.2.3"));
+    expect(within(tooltip).getByText(BRAND_NAME)).toBeVisible();
+    expect(buildBrandTooltip("   ")).toBe(`${BRAND_NAME} Unknown\n${BRAND_TAGLINE}`);
+  });
+});

--- a/apps/web/src/lib/app-shell/ViewModeToggleButton.svelte
+++ b/apps/web/src/lib/app-shell/ViewModeToggleButton.svelte
@@ -5,10 +5,8 @@
   import SettingsIcon from "$lib/components/icons/SettingsIcon.svelte";
   import SplitViewIcon from "$lib/components/icons/SplitViewIcon.svelte";
   import { setViewMode, shellState } from "$lib/stores/shell";
-  import type { ViewMode } from "./contracts";
   import DockToggleButton from "./DockToggleButton.svelte";
   import { ViewMode } from "./contracts";
-  import { getDockButtonClasses } from "./dockButtonClasses";
 
   const viewOptions: { id: ViewMode; label: string; Icon: typeof SplitViewIcon }[] = [
     { id: ViewMode.EditorPreview, label: "Editor & preview", Icon: SplitViewIcon },

--- a/apps/web/src/lib/app-shell/toolbar.constants.ts
+++ b/apps/web/src/lib/app-shell/toolbar.constants.ts
@@ -1,6 +1,22 @@
 export const BRAND_NAME = "Kelpie";
 export const BRAND_TAGLINE = "Markdown to-do studio — edit, preview, and fine-tune your flow.";
 
+export const TOOLBAR_TEST_IDS = {
+  root: "toolbar",
+  brandCluster: "toolbar-brand-cluster",
+  controlsCluster: "toolbar-controls-cluster",
+  saveIndicatorWrapper: "toolbar-save-indicator-wrapper"
+} as const;
+
+export const TOOLBAR_WRAPPER_CLASSES =
+  "sticky top-0 z-30 flex w-full flex-wrap items-center justify-between gap-3 border-b border-base-300/70 bg-base-100/95 px-3 py-2 backdrop-blur";
+
+export const TOOLBAR_BRAND_CLUSTER_CLASSES = "flex items-center gap-3";
+
+export const TOOLBAR_CONTROLS_CLUSTER_CLASSES = "flex flex-1 flex-wrap items-center justify-end gap-3 sm:gap-4";
+
+export const TOOLBAR_SAVE_INDICATOR_WRAPPER_CLASSES = "sm:w-auto";
+
 export function buildBrandTooltip(version: string): string {
   const versionLabel = version.trim() || "Unknown";
   return `${BRAND_NAME} ${versionLabel}\n${BRAND_TAGLINE}`;

--- a/specs/toolbar.spec.md
+++ b/specs/toolbar.spec.md
@@ -48,13 +48,19 @@ the workspace.
 
 ## Structure
 
+- Layout utility tokens for the wrapper, brand cluster, controls cluster, and
+  save indicator wrapper live in `toolbar.constants.ts` so Tailwind class lists
+  stay co-located with other toolbar primitives.
 - `<header>` wrapper uses a sticky position at the top with slight background
   transparency and blur so content scrolls beneath it without losing contrast.
 - Left cluster renders the `ToolbarBrand` subcomponent which encapsulates all
-  branding copy, tooltip composition, and typography styles.
-- Right cluster (`flex-1` container):
+  branding copy, tooltip composition, and typography styles. The cluster is
+  addressable via `data-testid="toolbar-brand-cluster"` for instrumentation.
+- Right cluster (`flex-1` container) is exported as
+  `TOOLBAR_CONTROLS_CLUSTER_CLASSES` and carries `data-testid="toolbar-controls-cluster"`:
   - `PanelToggleGroup` (renders only when layout is mobile via its own logic).
-  - `SaveIndicator` contained in a width-constrained wrapper for stability.
+  - `SaveIndicator` contained in a width-constrained wrapper for stability and
+    labeled with `data-testid="toolbar-save-indicator-wrapper"`.
   - `ViewModeToggleButton` for switching between editor/preview/settings modes.
   - `ThemeToggleButton` for switching between light/dark themes.
 
@@ -113,6 +119,11 @@ the workspace.
 - Toolbar composition favors declarative stacking of imported components instead
   of inline helpers, so future additions (e.g., help menus) can be inserted by
   adding one more component import.
+- Layout class tokens and testing IDs are centralized in
+  `toolbar.constants.ts`, keeping styling, instrumentation, and tests aligned
+  without string duplication inside the Svelte markup.
+- `TOOLBAR_TEST_IDS` expose stable selectors so unit tests can target
+  high-level clusters without depending on specific DOM structures.
 
 ## Test Scenarios (Gherkin)
 
@@ -141,6 +152,11 @@ Feature: Toolbar interactions
     When I toggle the theme from the toolbar
     Then the document theme should be "dark"
     And the theme toggle label reads "Switch to light theme"
+
+  Scenario: Toolbar exposes stable layout clusters
+    Then the toolbar root uses the exported wrapper classes
+    And the brand cluster test id is available for instrumentation
+    And the controls cluster includes the save indicator wrapper and workspace controls
 
   Scenario: Panel toggle group only appears on mobile layouts
     When I resize the viewport to "mobile"


### PR DESCRIPTION
## Summary
- centralize toolbar layout classes and test ids in `toolbar.constants.ts` and apply them in the toolbar markup
- add coverage for toolbar layout, tooltip copy, and instrumentation along with panel toggle test updates
- tidy duplicate imports in shell toggles and document the new structure and selectors in the toolbar spec

## Testing
- pnpm --filter web test:unit -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d706f021c08329b566ae45d0e5d5bf