### PR TITLE
feat: harden storage driver and add corruption recovery

### DIFF
--- a/apps/web/src/lib/stores/storage/core.ts
+++ b/apps/web/src/lib/stores/storage/core.ts
@@ -1,5 +1,6 @@
 import { STORAGE_SCHEMA_VERSION } from "./constants";
 import { createDefaultConfiguration, createInitialSnapshot } from "./defaults";
+import { appendAuditEntries, createAuditEntry } from "./audit";
 import type { StorageDriver } from "./driver";
 import {
   captureHistorySnapshot,
@@ -58,13 +59,42 @@ export function createStorageCore(options: StorageCoreOptions): StorageCore {
   const now = options.now ?? (() => new Date().toISOString());
   const broadcast = options.broadcast ?? (() => {});
 
-  const loadedSnapshot = driver.load() ?? createInitialSnapshot();
+  let corruptionAudit: ReturnType<typeof createAuditEntry> | null = null;
+  const loadedSnapshot =
+    driver.load({
+      onCorruption(error) {
+        const metadata: Record<string, unknown> = {
+          reason: error.reason
+        };
+
+        if (error.expectedChecksum || error.actualChecksum) {
+          const checksum: Record<string, string> = {};
+          if (error.expectedChecksum) {
+            checksum.expected = error.expectedChecksum;
+          }
+          if (error.actualChecksum) {
+            checksum.actual = error.actualChecksum;
+          }
+          metadata.checksum = checksum;
+        }
+
+        corruptionAudit = createAuditEntry("storage.corruption", now(), metadata);
+      }
+    }) ?? createInitialSnapshot();
+
   const migrationResult = runMigrations(loadedSnapshot, STORAGE_SCHEMA_VERSION, { now });
 
   let initialSnapshot = migrationResult.snapshot;
 
-  if (migrationResult.applied.length) {
-    const prepared = normaliseSnapshotForPersistence(migrationResult.snapshot, { now });
+  if (corruptionAudit) {
+    const nextAudit = appendAuditEntries(initialSnapshot, corruptionAudit);
+    initialSnapshot = { ...initialSnapshot, audit: nextAudit } satisfies StorageSnapshot;
+  }
+
+  const shouldPersist = migrationResult.applied.length > 0 || Boolean(corruptionAudit);
+
+  if (shouldPersist) {
+    const prepared = normaliseSnapshotForPersistence(initialSnapshot, { now });
     driver.save(prepared.snapshot);
     initialSnapshot = prepared.snapshot;
   }

--- a/apps/web/src/lib/stores/storage/driver.ts
+++ b/apps/web/src/lib/stores/storage/driver.ts
@@ -1,53 +1,295 @@
 import { getLocalStorage, getWindow } from "./environment";
 import { storageWarn } from "./logging";
-import type { StorageSnapshot } from "./types";
+import { serialiseSnapshot } from "./serialization";
+import type { IsoDateTimeString, StorageSnapshot } from "./types";
 
-/**
- * Abstraction over the host storage API (localStorage for MVP).
- *
- * Having a thin driver interface makes it straightforward to swap in
- * alternative persistence layers in future tasks or tests.
- */
-export interface StorageDriver {
-  load(): StorageSnapshot | null;
+export type StorageLoadOptions = {
+  onCorruption?: (error: StorageCorruptionError) => void;
+};
+
+export type CreateLocalStorageDriverOptions = {
+  now?: () => IsoDateTimeString;
+  backupLimit?: number;
+};
+
+export type StorageDriver = {
+  load(options?: StorageLoadOptions): StorageSnapshot | null;
   save(snapshot: StorageSnapshot): void;
   clear(): void;
-  /**
-   * Subscribe to external changes (e.g. storage events from other tabs).
-   * Returns an unsubscribe function.
-   */
   subscribe(callback: () => void): () => void;
+};
+
+export type StorageCorruptionReason = "parse" | "checksum";
+
+export class StorageCorruptionError extends Error {
+  readonly reason: StorageCorruptionReason;
+  readonly rawPayload: string;
+  readonly expectedChecksum?: string;
+  readonly actualChecksum?: string;
+  readonly details?: unknown;
+
+  constructor(
+    reason: StorageCorruptionReason,
+    message: string,
+    rawPayload: string,
+    options: { expectedChecksum?: string; actualChecksum?: string; details?: unknown } = {}
+  ) {
+    super(message);
+    this.name = "StorageCorruptionError";
+    this.reason = reason;
+    this.rawPayload = rawPayload;
+    this.expectedChecksum = options.expectedChecksum;
+    this.actualChecksum = options.actualChecksum;
+    this.details = options.details;
+  }
 }
 
-export function createLocalStorageDriver(key: string): StorageDriver {
+export class StorageDriverQuotaError extends Error {
+  readonly cause: unknown;
+
+  constructor(cause: unknown) {
+    super("storage quota exceeded");
+    this.name = "StorageQuotaError";
+    this.cause = cause;
+  }
+}
+
+type InternalStorage = Storage & { __kelpieFallback?: boolean };
+
+type MemoryStorageState = {
+  map: Map<string, string>;
+  order: string[];
+};
+
+function createMemoryStorage(): InternalStorage {
+  const state: MemoryStorageState = {
+    map: new Map(),
+    order: []
+  };
+
+  const storage: InternalStorage = {
+    get length() {
+      return state.order.length;
+    },
+    clear() {
+      state.map.clear();
+      state.order = [];
+    },
+    getItem(key: string): string | null {
+      if (!state.map.has(key)) {
+        return null;
+      }
+      return state.map.get(key) ?? null;
+    },
+    key(index: number): string | null {
+      return state.order[index] ?? null;
+    },
+    removeItem(key: string): void {
+      if (!state.map.has(key)) {
+        return;
+      }
+      state.map.delete(key);
+      state.order = state.order.filter((entry) => entry !== key);
+    },
+    setItem(key: string, value: string): void {
+      if (!state.map.has(key)) {
+        state.order.push(key);
+      }
+      state.map.set(key, value);
+    }
+  } as InternalStorage;
+
+  storage.__kelpieFallback = true;
+  return storage;
+}
+
+function computeChecksum(serialised: string): string {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < serialised.length; index += 1) {
+    hash ^= serialised.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return hash.toString(16).padStart(8, "0");
+}
+
+function sanitiseTimestamp(timestamp: IsoDateTimeString): string {
+  return timestamp.replace(/[:.]/g, "-");
+}
+
+function collectBackupKeys(storage: Storage, prefix: string): string[] {
+  const keys: string[] = [];
+  const { length } = storage;
+  for (let index = 0; index < length; index += 1) {
+    const key = storage.key(index);
+    if (!key) {
+      continue;
+    }
+    if (key.startsWith(prefix)) {
+      keys.push(key);
+    }
+  }
+  return keys.sort();
+}
+
+function isQuotaError(error: unknown): boolean {
+  if (typeof DOMException !== "undefined" && error instanceof DOMException) {
+    return error.name === "QuotaExceededError" || error.code === 22 || error.name === "NS_ERROR_DOM_QUOTA_REACHED";
+  }
+
+  if (typeof error === "object" && error && "code" in error && (error as { code?: number }).code === 22) {
+    return true;
+  }
+
+  return false;
+}
+
+export function createLocalStorageDriver(key: string, options: CreateLocalStorageDriverOptions = {}): StorageDriver {
+  const now = options.now ?? (() => new Date().toISOString());
+  const backupLimit = Math.max(0, options.backupLimit ?? 3);
+  const localStorageInstance = getLocalStorage();
+  const storage: InternalStorage = (localStorageInstance ?? createMemoryStorage()) as InternalStorage;
+  const useFallback = !!storage.__kelpieFallback;
+  const checksumKey = `${key}.checksum`;
+  const backupPrefix = `${key}.backup.`;
+  const fallbackSubscribers = new Set<() => void>();
+
+  let lastSerialised: string | null = null;
+  let lastChecksum: string | null = null;
+
+  function notifyFallbackSubscribers(): void {
+    if (!useFallback) {
+      return;
+    }
+    for (const listener of fallbackSubscribers) {
+      try {
+        listener();
+      } catch (error) {
+        storageWarn("storage fallback subscriber threw", error);
+      }
+    }
+  }
+
+  function writeBackup(raw: string): void {
+    if (backupLimit === 0) {
+      return;
+    }
+
+    const timestamp = sanitiseTimestamp(now());
+    const backupKey = `${backupPrefix}${timestamp}`;
+
+    try {
+      storage.setItem(backupKey, raw);
+    } catch (error) {
+      storageWarn("failed to persist storage backup", error);
+      return;
+    }
+
+    const backupKeys = collectBackupKeys(storage, backupPrefix);
+    if (backupKeys.length <= backupLimit) {
+      return;
+    }
+
+    const excess = backupKeys.length - backupLimit;
+    for (let index = 0; index < excess; index += 1) {
+      const keyToRemove = backupKeys[index];
+      try {
+        storage.removeItem(keyToRemove);
+      } catch (error) {
+        storageWarn("failed to prune storage backup", error);
+      }
+    }
+  }
+
+  function handleCorruption(error: StorageCorruptionError, callback?: StorageLoadOptions["onCorruption"]): void {
+    storageWarn(`storage snapshot corruption detected (${error.reason})`, error.details ?? error);
+    writeBackup(error.rawPayload);
+    callback?.(error);
+  }
+
   return {
-    load() {
-      const storage = getLocalStorage();
-      if (!storage) return null;
+    load(loadOptions) {
       const raw = storage.getItem(key);
-      if (!raw) return null;
+      if (!raw) {
+        lastSerialised = null;
+        lastChecksum = null;
+        return null;
+      }
+
+      const expectedChecksum = storage.getItem(checksumKey);
+      const actualChecksum = computeChecksum(raw);
+
+      if (expectedChecksum && expectedChecksum !== actualChecksum) {
+        handleCorruption(
+          new StorageCorruptionError("checksum", "storage snapshot checksum mismatch", raw, {
+            expectedChecksum,
+            actualChecksum
+          }),
+          loadOptions?.onCorruption
+        );
+        return null;
+      }
 
       try {
-        return JSON.parse(raw) as StorageSnapshot;
+        const parsed = JSON.parse(raw) as StorageSnapshot;
+        lastSerialised = raw;
+        lastChecksum = actualChecksum;
+        return parsed;
       } catch (error) {
-        storageWarn("failed to parse snapshot", error);
-        throw error;
+        handleCorruption(
+          new StorageCorruptionError("parse", "failed to parse storage snapshot", raw, { details: error }),
+          loadOptions?.onCorruption
+        );
+        return null;
       }
     },
     save(snapshot) {
-      const storage = getLocalStorage();
-      if (!storage) return;
-      storage.setItem(key, JSON.stringify(snapshot));
+      const serialised = serialiseSnapshot(snapshot);
+      const checksum = computeChecksum(serialised);
+
+      if (lastSerialised === serialised && lastChecksum === checksum) {
+        return;
+      }
+
+      const previous = storage.getItem(key);
+      if (previous && previous !== serialised) {
+        writeBackup(previous);
+      }
+
+      try {
+        storage.setItem(key, serialised);
+        storage.setItem(checksumKey, checksum);
+      } catch (error) {
+        if (isQuotaError(error)) {
+          throw new StorageDriverQuotaError(error);
+        }
+        throw error;
+      }
+
+      lastSerialised = serialised;
+      lastChecksum = checksum;
+
+      notifyFallbackSubscribers();
     },
     clear() {
-      const storage = getLocalStorage();
-      if (!storage) return;
       storage.removeItem(key);
+      storage.removeItem(checksumKey);
+      lastSerialised = null;
+      lastChecksum = null;
+      notifyFallbackSubscribers();
     },
     subscribe(callback) {
       const host = getWindow();
+      let unsubscribeFallback = () => {};
+
+      if (useFallback) {
+        fallbackSubscribers.add(callback);
+        unsubscribeFallback = () => {
+          fallbackSubscribers.delete(callback);
+        };
+      }
+
       if (!host) {
-        return () => {};
+        return unsubscribeFallback;
       }
 
       const handler = (event: StorageEvent) => {
@@ -57,7 +299,10 @@ export function createLocalStorageDriver(key: string): StorageDriver {
       };
 
       host.addEventListener("storage", handler);
-      return () => host.removeEventListener("storage", handler);
+      return () => {
+        unsubscribeFallback();
+        host.removeEventListener("storage", handler);
+      };
     }
-  };
+  } satisfies StorageDriver;
 }

--- a/apps/web/src/lib/stores/storage/index.ts
+++ b/apps/web/src/lib/stores/storage/index.ts
@@ -10,4 +10,5 @@ export * from "./documents";
 export * from "./migrations";
 export * from "./garbage-collection";
 export * from "./size";
+export * from "./serialization";
 export * from "./types";

--- a/apps/web/src/lib/stores/storage/serialization.ts
+++ b/apps/web/src/lib/stores/storage/serialization.ts
@@ -1,0 +1,62 @@
+import type { StorageSnapshot } from "./types";
+
+type CanonicalValue = null | string | number | boolean | CanonicalValue[] | { [key: string]: CanonicalValue };
+
+function toCanonical(value: unknown): CanonicalValue {
+  if (value === undefined) {
+    return null;
+  }
+
+  if (value === null) {
+    return null;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => toCanonical(item));
+  }
+
+  if (typeof value === "object") {
+    const entries = Object.entries(value as Record<string, unknown>).sort(([a], [b]) => a.localeCompare(b));
+
+    const canonical: Record<string, CanonicalValue> = {};
+    for (const [key, item] of entries) {
+      if (item === undefined) {
+        continue;
+      }
+      canonical[key] = toCanonical(item);
+    }
+    return canonical;
+  }
+
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+    return value;
+  }
+
+  if (typeof value === "number" && !Number.isFinite(value)) {
+    return null;
+  }
+
+  if (typeof value === "bigint") {
+    return Number(value);
+  }
+
+  const stringified = JSON.stringify(value);
+  if (typeof stringified === "undefined") {
+    return null;
+  }
+
+  return JSON.parse(stringified) as CanonicalValue;
+}
+
+export function serialiseSnapshot(snapshot: StorageSnapshot): string {
+  const canonical = toCanonical(snapshot);
+  return JSON.stringify(canonical);
+}
+
+export function measureSerializedLength(value: string): number {
+  if (typeof TextEncoder !== "undefined") {
+    return new TextEncoder().encode(value).length;
+  }
+
+  return value.length;
+}

--- a/apps/web/src/lib/stores/storage/size.ts
+++ b/apps/web/src/lib/stores/storage/size.ts
@@ -1,13 +1,7 @@
+import { serialiseSnapshot, measureSerializedLength } from "./serialization";
 import type { StorageSnapshot } from "./types";
 
-function encodeLength(value: string): number {
-  if (typeof TextEncoder !== "undefined") {
-    return new TextEncoder().encode(value).length;
-  }
-  return value.length;
-}
-
 export function estimateSnapshotSize(snapshot: StorageSnapshot): number {
-  const json = JSON.stringify(snapshot);
-  return encodeLength(json);
+  const json = serialiseSnapshot(snapshot);
+  return measureSerializedLength(json);
 }

--- a/specs/storage.spec.md
+++ b/specs/storage.spec.md
@@ -689,10 +689,14 @@ This section is for the AI or developers to update after implementation runs.
   - Quota-aware garbage collection that normalises snapshots on write, prunes
     expired documents, trims history for warning thresholds, and records payload
     size metadata alongside audit warnings
+  - Corruption recovery pipeline that falls back to defaults, rotates backups,
+    and records `storage.corruption` audit entries (§20)
+  - Resilient local storage driver with deterministic serialisation, checksum
+    validation, rotating backups, in-memory fallback, and quota-aware error
+    surfacing (§22–24)
 
 - **What remains to be implemented**:
-  - Migration pipeline, corruption recovery, and developer inspector tooling described in §§20–21.
-  - Driver resilience features (backups, fallbacks, quota errors) and telemetry instrumentation from §§22–24.
+  - Developer inspector tooling described in §21 and deeper telemetry hooks from §24.
   - Privacy toggles, encryption hooks, and compliance-aware audit policies from §25.
 
 - **Test files and coverage**:


### PR DESCRIPTION
## Summary
- add deterministic snapshot serialization with checksum validation, rotating backups, and fallback support in the storage driver
- surface corruption recovery in the storage core by recording audit entries and persisting reset snapshots
- expand unit coverage for driver and core, plus update the storage spec to reflect the completed work

## Testing
- pnpm --filter web exec vitest run src/lib/stores/storage/driver.test.ts src/lib/stores/storage/core.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d70612e9788329b62d068a7ceb3c75