### PR TITLE
Refactor SaveIndicator configuration for maintainability

### DIFF
--- a/apps/web/src/lib/app-shell/SaveIndicator.test.ts
+++ b/apps/web/src/lib/app-shell/SaveIndicator.test.ts
@@ -4,10 +4,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import SaveIndicator from "./SaveIndicator.svelte";
 import { SaveStatusKind } from "$lib/app-shell/contracts";
 import { markError, markSaved, markSaving, resetSaveStatus } from "$lib/stores/persistence";
-
-const localTooltip =
-  "Changes are stored locally on this device for now. Cloud sync will be introduced in a future release.";
-const errorTooltip = "We couldn't save locally. Retry or export your data to keep a copy while we work on cloud sync.";
+import { ERROR_TOOLTIP, LOCAL_SAVE_TOOLTIP } from "./save-indicator.config";
 
 describe("SaveIndicator", () => {
   afterEach(() => {
@@ -21,7 +18,7 @@ describe("SaveIndicator", () => {
     const indicator = screen.getByTestId("save-indicator");
     expect(indicator).toHaveAccessibleName(/Saved locally/);
     expect(indicator).toHaveAttribute("data-kind", SaveStatusKind.Idle);
-    expect(indicator).toHaveAttribute("title", localTooltip);
+    expect(indicator).toHaveAttribute("title", LOCAL_SAVE_TOOLTIP);
     expect(within(indicator).getByText("Saved locally ✓")).toBeVisible();
     expect(
       screen.queryByText((content) => content.startsWith("(") && content.includes(":") && content.endsWith(")"))
@@ -37,7 +34,7 @@ describe("SaveIndicator", () => {
     const indicator = screen.getByTestId("save-indicator");
     expect(indicator).toHaveAccessibleName(/Saving locally/);
     expect(indicator).toHaveAttribute("data-kind", SaveStatusKind.Saving);
-    expect(indicator).toHaveAttribute("title", localTooltip);
+    expect(indicator).toHaveAttribute("title", LOCAL_SAVE_TOOLTIP);
     const label = within(indicator).getByText("Saving locally…");
     expect(label).toBeVisible();
     expect(indicator.className).toContain("animate-pulse");
@@ -68,7 +65,7 @@ describe("SaveIndicator", () => {
     const indicator = screen.getByTestId("save-indicator");
     expect(indicator).toHaveAccessibleName(/Disk full/);
     expect(indicator).toHaveAttribute("data-kind", SaveStatusKind.Error);
-    expect(indicator).toHaveAttribute("title", errorTooltip);
+    expect(indicator).toHaveAttribute("title", ERROR_TOOLTIP);
     expect(within(indicator).getByText("Disk full")).toBeVisible();
   });
 });

--- a/apps/web/src/lib/app-shell/save-indicator.config.ts
+++ b/apps/web/src/lib/app-shell/save-indicator.config.ts
@@ -1,0 +1,65 @@
+import { SaveStatusKind } from "$lib/app-shell/contracts";
+import type { SaveStatus } from "$lib/app-shell/contracts";
+
+type ToneClasses = { badge: string; icon: string };
+
+type SaveIndicatorView = {
+  tone: ToneClasses;
+  tooltip: string;
+};
+
+export const LOCAL_SAVE_TOOLTIP =
+  "Changes are stored locally on this device for now. Cloud sync will be introduced in a future release.";
+export const ERROR_TOOLTIP =
+  "We couldn't save locally. Retry or export your data to keep a copy while we work on cloud sync.";
+
+export const DEFAULT_KIND = SaveStatusKind.Saved;
+
+export const SAVE_INDICATOR_CONFIG: Record<SaveStatus["kind"], SaveIndicatorView> = {
+  [SaveStatusKind.Idle]: {
+    tone: {
+      badge: "border-success/40 bg-success/10 text-success",
+      icon: "text-success"
+    },
+    tooltip: LOCAL_SAVE_TOOLTIP
+  },
+  [SaveStatusKind.Saving]: {
+    tone: {
+      badge: "border-info/40 bg-info/10 text-info",
+      icon: "text-info"
+    },
+    tooltip: LOCAL_SAVE_TOOLTIP
+  },
+  [SaveStatusKind.Saved]: {
+    tone: {
+      badge: "border-success/40 bg-success/10 text-success",
+      icon: "text-success"
+    },
+    tooltip: LOCAL_SAVE_TOOLTIP
+  },
+  [SaveStatusKind.Error]: {
+    tone: {
+      badge: "border-error/40 bg-error/10 text-error",
+      icon: "text-error"
+    },
+    tooltip: ERROR_TOOLTIP
+  }
+};
+
+const getConfigFor = (kind: SaveStatus["kind"]) => SAVE_INDICATOR_CONFIG[kind] ?? SAVE_INDICATOR_CONFIG[DEFAULT_KIND];
+
+export const toneFor = (kind: SaveStatus["kind"]) => getConfigFor(kind).tone;
+export const tooltipFor = (kind: SaveStatus["kind"]) => getConfigFor(kind).tooltip;
+
+export const getTimestampDetails = (status: SaveStatus) => {
+  if (status.kind !== SaveStatusKind.Saved || !status.timestamp) {
+    return undefined;
+  }
+
+  const formattedTime = new Date(status.timestamp).toLocaleTimeString();
+
+  return {
+    display: `(${formattedTime})`,
+    tooltipLine: `Last saved at ${formattedTime}.`
+  };
+};


### PR DESCRIPTION
## Summary
- centralize SaveIndicator tone, tooltip, and timestamp helpers in a shared configuration module
- refactor SaveIndicator.svelte to consume the shared helpers and emit timestamp metadata consistently
- update the feature spec and unit tests to rely on the shared configuration for copy and styling guidance

## Testing
- pnpm --filter web exec vitest run src/lib/app-shell/SaveIndicator.test.ts
- pnpm test:unit *(fails: PanelToggleGroup/ViewModeToggleButton compile errors present on main)*

------
https://chatgpt.com/codex/tasks/task_e_68d70869ff4c83299bfab5c893c74935