### PR TITLE
Improve toolbar spec and tests for maintainability

### DIFF
--- a/apps/web/src/lib/app-shell/Toolbar.test.ts
+++ b/apps/web/src/lib/app-shell/Toolbar.test.ts
@@ -1,41 +1,75 @@
-import { render, screen } from "@testing-library/svelte";
+import { render, screen, waitFor } from "@testing-library/svelte";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import Toolbar from "./Toolbar.svelte";
 import { PANEL_DEFINITIONS } from "./panels";
-import { ViewMode } from "./contracts";
+import { PanelId, ShellLayout, ViewMode } from "./contracts";
 import { activatePanel, setLayout, setViewMode } from "$lib/stores/shell";
 import { resetSaveStatus } from "$lib/stores/persistence";
+import {
+  TOOLBAR_BRAND_CLUSTER_CLASSES,
+  TOOLBAR_CONTROLS_CLUSTER_CLASSES,
+  TOOLBAR_SAVE_INDICATOR_WRAPPER_CLASSES,
+  TOOLBAR_TEST_IDS,
+  TOOLBAR_WRAPPER_CLASSES
+} from "./toolbar.constants";
 
 describe("Toolbar", () => {
-  beforeEach(() => {
-    setLayout("desktop");
+  function resetShellState() {
+    setLayout(ShellLayout.Desktop);
     setViewMode(ViewMode.EditorPreview);
-    activatePanel("editor");
+    activatePanel(PanelId.Editor);
     resetSaveStatus();
+  }
+
+  function renderToolbar(version = "1.2.3") {
+    return render(Toolbar, { version });
+  }
+
+  function expectElementHasClasses(element: HTMLElement, classes: string) {
+    for (const className of classes.split(/\s+/).filter(Boolean)) {
+      expect(element).toHaveClass(className);
+    }
+  }
+
+  beforeEach(() => {
+    resetShellState();
   });
 
   afterEach(() => {
-    setLayout("desktop");
-    setViewMode(ViewMode.EditorPreview);
-    activatePanel("editor");
-    resetSaveStatus();
+    resetShellState();
   });
 
   it("renders a branded tooltip that includes the app version", () => {
     const version = "1.2.3";
 
-    render(Toolbar, { version });
+    renderToolbar(version);
 
     const tooltip = screen.getByTestId("toolbar-brand-tooltip");
     expect(tooltip).toHaveAttribute("data-tip", expect.stringContaining(version));
     expect(screen.getByTestId("toolbar-brand-label")).toHaveTextContent("Kelpie");
   });
 
-  it("exposes panel toggles, save status, view mode controls, and theme switcher", () => {
-    setLayout("mobile");
+  it("applies exported layout classes and test ids to clusters", () => {
+    renderToolbar("2.0.0");
 
-    render(Toolbar, { version: "2.0.0" });
+    const root = screen.getByTestId(TOOLBAR_TEST_IDS.root);
+    expectElementHasClasses(root as HTMLElement, TOOLBAR_WRAPPER_CLASSES);
+
+    const brandCluster = screen.getByTestId(TOOLBAR_TEST_IDS.brandCluster);
+    expectElementHasClasses(brandCluster as HTMLElement, TOOLBAR_BRAND_CLUSTER_CLASSES);
+
+    const controlsCluster = screen.getByTestId(TOOLBAR_TEST_IDS.controlsCluster);
+    expectElementHasClasses(controlsCluster as HTMLElement, TOOLBAR_CONTROLS_CLUSTER_CLASSES);
+
+    const saveIndicatorWrapper = screen.getByTestId(TOOLBAR_TEST_IDS.saveIndicatorWrapper);
+    expectElementHasClasses(saveIndicatorWrapper as HTMLElement, TOOLBAR_SAVE_INDICATOR_WRAPPER_CLASSES);
+  });
+
+  it("exposes panel toggles, save status, view mode controls, and theme switcher", () => {
+    setLayout(ShellLayout.Mobile);
+
+    renderToolbar("2.0.0");
 
     const panelGroup = screen.getByTestId("panel-toggle-group");
     expect(panelGroup).toBeVisible();
@@ -52,5 +86,19 @@ describe("Toolbar", () => {
     }
 
     expect(screen.getByRole("button", { name: /Switch to (dark|light) theme/i })).toBeVisible();
+  });
+
+  it("only renders panel toggles when the shell layout is mobile", async () => {
+    renderToolbar("3.0.0");
+
+    expect(screen.queryByTestId("panel-toggle-group")).not.toBeInTheDocument();
+
+    setLayout(ShellLayout.Mobile);
+    expect(await screen.findByTestId("panel-toggle-group")).toBeVisible();
+
+    setLayout(ShellLayout.Desktop);
+    await waitFor(() => {
+      expect(screen.queryByTestId("panel-toggle-group")).not.toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
## Summary
- document constant reuse and DOM expectations in the toolbar spec to keep implementation and tests aligned
- refactor the toolbar unit tests to reuse enums/constants instead of string literals
- add coverage for exported class tokens and the mobile-only panel toggle group rendering

## Testing
- pnpm --filter web exec vitest run src/lib/app-shell/Toolbar.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d70984e5a8832990f096713b85a671