### PR TITLE
Add robust app shell and icon tests

### DIFF
--- a/apps/web/src/lib/app-shell/AppShell.test.ts
+++ b/apps/web/src/lib/app-shell/AppShell.test.ts
@@ -1,0 +1,119 @@
+import { render, screen } from "@testing-library/svelte";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+import AppShell from "./AppShell.svelte";
+import { PANEL_DEFINITIONS, getVisiblePanels } from "./panels";
+import { PanelId, ShellLayout, ViewMode, isPanelAllowedInMode } from "./contracts";
+import { activatePanel, setLayout, setViewMode } from "$lib/stores/shell";
+
+type RenderShellOptions = {
+  layout?: ShellLayout;
+  viewMode?: ViewMode;
+  activePanel?: PanelId;
+};
+
+type MatchMediaStub = ReturnType<typeof createMatchMediaStub>;
+
+function createMatchMediaStub(matchesRef: { value: boolean }) {
+  return (query: string): MediaQueryList => ({
+    matches: matchesRef.value,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(() => false)
+  });
+}
+
+describe("AppShell", () => {
+  const matchMediaState = { value: false };
+  let matchMedia: MatchMediaStub;
+
+  beforeAll(() => {
+    matchMedia = createMatchMediaStub(matchMediaState);
+    vi.stubGlobal("matchMedia", matchMedia);
+  });
+
+  afterAll(() => {
+    vi.unstubAllGlobals();
+  });
+
+  beforeEach(() => {
+    setLayout(ShellLayout.Desktop);
+    setViewMode(ViewMode.EditorPreview);
+    activatePanel(PanelId.Editor);
+  });
+
+  afterEach(() => {
+    setLayout(ShellLayout.Desktop);
+    setViewMode(ViewMode.EditorPreview);
+    activatePanel(PanelId.Editor);
+  });
+
+  function renderShell({
+    layout = ShellLayout.Desktop,
+    viewMode = ViewMode.EditorPreview,
+    activePanel
+  }: RenderShellOptions = {}) {
+    matchMediaState.value = layout === ShellLayout.Mobile;
+    setLayout(layout);
+    setViewMode(viewMode);
+    if (activePanel) {
+      activatePanel(activePanel);
+    }
+
+    return render(AppShell, {
+      props: { version: "1.0.0" }
+    });
+  }
+
+  it("syncs the rendered panel regions with the active layout state on desktop", () => {
+    renderShell({ layout: ShellLayout.Desktop, viewMode: ViewMode.EditorPreview });
+
+    const visiblePanels = getVisiblePanels(ViewMode.EditorPreview);
+
+    for (const panel of visiblePanels) {
+      const region = screen.getByTestId(`panel-${panel.id}`);
+      expect(region).toHaveAttribute("data-panel", panel.id);
+      expect(region).toHaveAttribute("aria-label", panel.label);
+      expect(region).toHaveAttribute("data-allowed", "true");
+      expect(region).toHaveAttribute("data-active", "true");
+      expect(region).not.toHaveAttribute("hidden");
+    }
+
+    const hiddenPanels = PANEL_DEFINITIONS.filter((panel) => !isPanelAllowedInMode(panel.id, ViewMode.EditorPreview));
+    for (const panel of hiddenPanels) {
+      expect(screen.queryByTestId(`panel-${panel.id}`)).not.toBeInTheDocument();
+    }
+  });
+
+  it("hides inactive panels on mobile layouts while keeping accessible metadata", () => {
+    renderShell({ layout: ShellLayout.Mobile, viewMode: ViewMode.EditorPreview, activePanel: PanelId.Preview });
+
+    const editorPanel = screen.getByTestId("panel-editor");
+    expect(editorPanel).toHaveAttribute("data-active", "false");
+    expect(editorPanel).toHaveAttribute("data-allowed", "true");
+    expect(editorPanel).toHaveAttribute("hidden");
+
+    const previewPanel = screen.getByTestId("panel-preview");
+    expect(previewPanel).toHaveAttribute("data-active", "true");
+    expect(previewPanel).toHaveAttribute("data-allowed", "true");
+    expect(previewPanel).not.toHaveAttribute("hidden");
+  });
+
+  it("only renders panels that are allowed in the current view mode", () => {
+    renderShell({ layout: ShellLayout.Desktop, viewMode: ViewMode.Settings });
+
+    const visiblePanels = getVisiblePanels(ViewMode.Settings);
+    for (const panel of visiblePanels) {
+      expect(screen.getByTestId(`panel-${panel.id}`)).toBeInTheDocument();
+    }
+
+    const disallowedPanels = PANEL_DEFINITIONS.filter((panel) => !isPanelAllowedInMode(panel.id, ViewMode.Settings));
+    for (const panel of disallowedPanels) {
+      expect(screen.queryByTestId(`panel-${panel.id}`)).not.toBeInTheDocument();
+    }
+  });
+});

--- a/apps/web/src/lib/app-shell/PanelToggleGroup.test.ts
+++ b/apps/web/src/lib/app-shell/PanelToggleGroup.test.ts
@@ -8,7 +8,7 @@ import { PanelId } from "./contracts";
 import { PANEL_DEFINITIONS, PANEL_LABELS } from "./panels";
 import { activatePanel, setLayout, setViewMode, shellState } from "$lib/stores/shell";
 
-const PANEL_ORDER = PANEL_DEFINITIONS.map((panel) => panel.id);
+const PANEL_METADATA = PANEL_DEFINITIONS;
 
 function panelLabel(panel: PanelId): string {
   return PANEL_LABELS[panel];
@@ -41,6 +41,9 @@ describe("PanelToggleGroup", () => {
     const group = screen.getByRole("group", { name: "Select active panel" });
     const buttons = within(group).getAllByRole("button");
     expect(buttons).toHaveLength(PANEL_METADATA.length);
+    expect(buttons.map((button) => button.getAttribute("data-testid"))).toEqual(
+      PANEL_METADATA.map((panel) => `panel-toggle-${panel.id}`)
+    );
     const state = get(shellState);
 
     for (const { id } of PANEL_METADATA) {

--- a/apps/web/src/lib/components/icons/icons.test.ts
+++ b/apps/web/src/lib/components/icons/icons.test.ts
@@ -1,0 +1,41 @@
+import { render } from "@testing-library/svelte";
+import { describe, expect, it } from "vitest";
+
+import EditorIcon from "./EditorIcon.svelte";
+import PreviewIcon from "./PreviewIcon.svelte";
+import SettingsIcon from "./SettingsIcon.svelte";
+import SplitViewIcon from "./SplitViewIcon.svelte";
+
+type IconCase = {
+  name: string;
+  component: typeof EditorIcon;
+  defaultClassName: string;
+};
+
+const ICON_CASES: IconCase[] = [
+  { name: "EditorIcon", component: EditorIcon, defaultClassName: "h-4 w-4" },
+  { name: "PreviewIcon", component: PreviewIcon, defaultClassName: "h-4 w-4" },
+  { name: "SettingsIcon", component: SettingsIcon, defaultClassName: "h-4 w-4" },
+  { name: "SplitViewIcon", component: SplitViewIcon, defaultClassName: "h-5 w-5" }
+];
+
+describe("icons", () => {
+  for (const { name, component, defaultClassName } of ICON_CASES) {
+    it(`${name} forwards its className prop to the root svg element`, () => {
+      const { container: defaultContainer } = render(component);
+      const svg = defaultContainer.querySelector("svg");
+
+      expect(svg).toBeInstanceOf(SVGElement);
+      expect(svg).toHaveAttribute("class", defaultClassName);
+
+      const customClassName = "h-10 w-10 text-primary";
+      const { container: customContainer } = render(component, {
+        props: { className: customClassName }
+      });
+
+      const customSvg = customContainer.querySelector("svg");
+      expect(customSvg).toBeInstanceOf(SVGElement);
+      expect(customSvg).toHaveAttribute("class", customClassName);
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- add focused AppShell tests that exercise layout, view-mode, and active panel metadata without coupling to styling details
- introduce shared icon component tests that verify default and custom class handling across SVG icons
- align the PanelToggleGroup tests with panel definitions to keep assertions resilient to panel configuration changes

## Testing
- pnpm --filter web exec vitest run src/lib/app-shell/PanelToggleGroup.test.ts src/lib/app-shell/AppShell.test.ts src/lib/components/icons/icons.test.ts
- pnpm --filter web exec vitest run

------
https://chatgpt.com/codex/tasks/task_e_68d709b9318c8329a0f6cd27ad995cc1