### PR TITLE
Fix lint warnings in app shell components

### DIFF
--- a/apps/web/src/lib/app-shell/AppShell.svelte
+++ b/apps/web/src/lib/app-shell/AppShell.svelte
@@ -4,7 +4,7 @@
   import { onDestroy } from "svelte";
   import Toolbar from "./Toolbar.svelte";
   import { shellState, startLayoutWatcher } from "$lib/stores/shell";
-  import { PanelId, ShellLayout, isPanelAllowedInMode } from "./contracts";
+  import { PanelId, isPanelAllowedInMode } from "./contracts";
   import { getVisiblePanels, type PanelDefinition } from "./panels";
 
   export let version = "0.0.0";

--- a/apps/web/src/lib/app-shell/PanelToggleGroup.test.ts
+++ b/apps/web/src/lib/app-shell/PanelToggleGroup.test.ts
@@ -8,8 +8,6 @@ import { PanelId } from "./contracts";
 import { PANEL_DEFINITIONS, PANEL_LABELS } from "./panels";
 import { activatePanel, setLayout, setViewMode, shellState } from "$lib/stores/shell";
 
-const PANEL_ORDER = PANEL_DEFINITIONS.map((panel) => panel.id);
-
 function panelLabel(panel: PanelId): string {
   return PANEL_LABELS[panel];
 }
@@ -40,10 +38,10 @@ describe("PanelToggleGroup", () => {
 
     const group = screen.getByRole("group", { name: "Select active panel" });
     const buttons = within(group).getAllByRole("button");
-    expect(buttons).toHaveLength(PANEL_METADATA.length);
+    expect(buttons).toHaveLength(PANEL_DEFINITIONS.length);
     const state = get(shellState);
 
-    for (const { id } of PANEL_METADATA) {
+    for (const { id } of PANEL_DEFINITIONS) {
       const button = within(group).getByRole("button", { name: panelLabel(id) });
       expect(button).toBeVisible();
       expect(button).toHaveAttribute("aria-pressed", String(state.activePanel === id));


### PR DESCRIPTION
## Summary
- remove the unused `ShellLayout` import in the app shell component
- update the panel toggle group tests to reference the exported panel definitions directly

## Testing
- CI=1 pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d70bcca68c8329821bd95656c34a25