### PR TITLE
Fix duplicate save status step definition

### DIFF
--- a/apps/web/e2e/steps/save-indicator.steps.ts
+++ b/apps/web/e2e/steps/save-indicator.steps.ts
@@ -149,10 +149,6 @@ Given("the user has the app shell open", async ({ page }) => {
   await loadAppShell(page);
 });
 
-When("the save status store reports {string}", async ({ page }, kind: string) => {
-  await setSaveStatus(page, { kind: parseSaveStatusKind(kind) });
-});
-
 Given("the save status store reports {string}", async ({ page }, kind: string) => {
   await setSaveStatus(page, { kind: parseSaveStatusKind(kind) });
 });


### PR DESCRIPTION
## Summary
- remove the duplicate step definition for the save status store reports step to prevent ambiguous matches during e2e setup

## Testing
- pnpm test:e2e *(fails: Command "playwright" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d70dbaf48883298d6fc282ab600063