### PR TITLE
chore: fix lint warnings

### DIFF
--- a/apps/web/src/lib/app-shell/PanelToggleGroup.test.ts
+++ b/apps/web/src/lib/app-shell/PanelToggleGroup.test.ts
@@ -39,7 +39,7 @@ describe("PanelToggleGroup", () => {
     const group = screen.getByRole("group", { name: "Select active panel" });
     const buttons = within(group).getAllByRole("button");
     expect(buttons).toHaveLength(PANEL_DEFINITIONS.length);
-    
+
     const state = get(shellState);
 
     for (const { id } of PANEL_DEFINITIONS) {


### PR DESCRIPTION
## Summary
- remove extraneous whitespace in PanelToggleGroup test to satisfy Prettier linting

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d70d82371883298507b3128cbddeb3