### PR TITLE
test: silence storage warnings

### DIFF
--- a/apps/web/src/lib/stores/storage/broadcast.test.ts
+++ b/apps/web/src/lib/stores/storage/broadcast.test.ts
@@ -150,6 +150,7 @@ describe("scheduleBroadcast", () => {
     vi.resetModules();
 
     const storage = createStorageMock();
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const postMessageSpy = vi.fn(() => {
       throw new Error("post failed");
     });
@@ -185,6 +186,7 @@ describe("scheduleBroadcast", () => {
     expect(postMessageSpy).toHaveBeenCalledTimes(1);
     expect(close).toHaveBeenCalledTimes(1);
     expect(storage.setItem).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledWith("Kelpie storage: failed to post broadcast message", expect.any(Error));
 
     const followUp: StorageBroadcast = {
       scope: StorageBroadcastScope.History,
@@ -201,5 +203,7 @@ describe("scheduleBroadcast", () => {
     const parsed = JSON.parse(secondRaw as string);
     expect(parsed.scope).toBe(followUp.scope);
     expect(parsed.__sequence).toBe(1);
+
+    warnSpy.mockRestore();
   });
 });

--- a/apps/web/src/lib/stores/storage/driver.test.ts
+++ b/apps/web/src/lib/stores/storage/driver.test.ts
@@ -90,9 +90,14 @@ describe("createLocalStorageDriver", () => {
     globalThis.localStorage.setItem(`${STORAGE_KEY}.checksum`, "invalid-checksum");
 
     const corruption = vi.fn();
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     expect(driver.load({ onCorruption: corruption })).toBeNull();
     expect(corruption).toHaveBeenCalledTimes(1);
     expect(corruption.mock.calls[0][0]).toMatchObject({ reason: "checksum" });
+    expect(warnSpy).toHaveBeenCalledWith(
+      `${STORAGE_LOG_PREFIX}: storage snapshot corruption detected (checksum)`,
+      expect.objectContaining({ reason: "checksum" })
+    );
 
     const backupKey = `${STORAGE_KEY}.backup.${now().replace(/[:.]/g, "-")}`;
     expect(globalThis.localStorage.getItem(backupKey)).toContain("tampered");


### PR DESCRIPTION
## Summary
- stub the broadcast failure test to silence console warnings while asserting the logged error
- mock console.warn in the checksum corruption test so the warning is verified without noisy output

## Testing
- pnpm test:unit

------
https://chatgpt.com/codex/tasks/task_e_68d70de936708329b16cc848e40a5366