### PR TITLE
Fix InteractivePreviewPanel enum usage for Svelte build

### DIFF
--- a/apps/web/src/lib/panels/preview/InteractivePreviewPanel.svelte
+++ b/apps/web/src/lib/panels/preview/InteractivePreviewPanel.svelte
@@ -10,10 +10,12 @@
   export let tasks: Task[] = [];
   export let content = "";
 
-  enum ViewMode {
-    Tasks = "tasks",
-    Markdown = "markdown"
-  }
+  const ViewMode = {
+    Tasks: "tasks",
+    Markdown: "markdown"
+  } as const;
+
+  type ViewMode = (typeof ViewMode)[keyof typeof ViewMode];
 
   let view: ViewMode = ViewMode.Tasks;
 


### PR DESCRIPTION
## Summary
- replace the `ViewMode` enum with a const object to satisfy Svelte's TypeScript support

## Testing
- pnpm --filter web build


------
https://chatgpt.com/codex/tasks/task_e_68d70e107b088329ac6f3242ebd7e53e