### PR TITLE
Add missing toolbar and save indicator BDD steps

### DIFF
--- a/apps/web/e2e/features/save-indicator.spec.1.feature
+++ b/apps/web/e2e/features/save-indicator.spec.1.feature
@@ -1,0 +1,29 @@
+Feature: Save status indicator
+  The toolbar badge communicates persistence state so users trust the offline save system.
+
+  Background:
+    Given the user has the app shell open
+
+  Scenario: Viewing the idle state on load
+    When the save status store reports "idle"
+    Then the indicator shows "Saved locally ✓"
+    And the badge tone is styled for success
+    And the tooltip explains that changes are stored locally for now
+
+  Scenario: Seeing feedback while saving
+    Given the save status store reports "saving"
+    Then the indicator shows "Saving locally…"
+    And the badge pulses to indicate activity
+    And the tooltip still describes local storage
+
+  Scenario: Showing a timestamp after a successful save
+    Given the save status store reports "saved" with a recent timestamp
+    Then the indicator shows "Saved locally ✓"
+    And the timestamp is displayed in parentheses with the local time
+    And the tooltip includes the last saved time on a new line
+
+  Scenario: Surfacing a persistence error
+    Given the save status store reports "error" with message "Disk full"
+    Then the indicator shows "Disk full"
+    And the badge tone switches to error styling
+    And the tooltip advises retrying or exporting data

--- a/apps/web/e2e/features/toolbar.spec.1.feature
+++ b/apps/web/e2e/features/toolbar.spec.1.feature
@@ -1,0 +1,37 @@
+Feature: Toolbar interactions
+  The toolbar should keep key workspace controls available across devices.
+
+  Background:
+    Given I open the app with "basic.md"
+
+  Scenario: Branding tooltip communicates version and purpose
+    Then the toolbar brand tooltip contains "Kelpie 0.0.0-dev"
+    And the tooltip explains it is the markdown to-do studio
+
+  Scenario: Save indicator is always present
+    Then the toolbar displays the save indicator component
+    And the save indicator announces updates politely
+
+  Scenario: View mode switch updates shell state
+    When I choose the "Preview" view mode
+    Then the "Preview" panel should be visible
+    And the "Preview" view mode toggle is marked as active
+
+  Scenario: Theme toggle reflects current theme
+    Given the stored theme preference is cleared
+    When I toggle the theme from the toolbar
+    Then the document theme should be "dark"
+    And the theme toggle label reads "Switch to light theme"
+
+  Scenario: Toolbar exposes stable layout clusters
+    Then the toolbar root uses the exported wrapper classes
+    And the brand cluster test id is available for instrumentation
+    And the controls cluster includes the save indicator wrapper and workspace controls
+    And each cluster reuses the exported layout class tokens
+
+  Scenario: Panel toggle group only appears on mobile layouts
+    When I resize the viewport to "mobile"
+    Then the layout should be "mobile"
+    And the panel toggle group is visible within the toolbar
+    When I resize the viewport to "desktop"
+    Then the panel toggle group is hidden from the DOM

--- a/apps/web/e2e/steps/save-indicator.steps.ts
+++ b/apps/web/e2e/steps/save-indicator.steps.ts
@@ -153,6 +153,16 @@ Given("the save status store reports {string}", async ({ page }, kind: string) =
   await setSaveStatus(page, { kind: parseSaveStatusKind(kind) });
 });
 
+Given(
+  "the save status store reports {string} with message {string}",
+  async ({ page }, kind: string, message: string) => {
+    await setSaveStatus(page, {
+      kind: parseSaveStatusKind(kind),
+      message
+    });
+  }
+);
+
 Given("the save status store reports {string} with a recent timestamp", async ({ page }, kind: string) => {
   const isoTimestamp = new Date().toISOString();
   await setSaveStatus(page, { kind: parseSaveStatusKind(kind), timestamp: isoTimestamp });


### PR DESCRIPTION
## Summary
- add a save indicator step for explicitly setting persistence error messages
- assert toolbar layout clusters reuse exported class tokens and expose expected controls
- check in the generated toolbar and save indicator feature specs to cover the new steps

## Testing
- pnpm --filter web spec:extract
- pnpm --filter web test:e2e *(fails: Playwright browsers not installed in CI image)*

------
https://chatgpt.com/codex/tasks/task_e_68d70e85218883298231e58650d9e273