### PR TITLE
refactor: replace enums with const literals

### DIFF
--- a/apps/web/src/lib/app-shell/contracts.ts
+++ b/apps/web/src/lib/app-shell/contracts.ts
@@ -2,11 +2,13 @@
  * Types describing the contracts between the app shell and its child panels.
  * These mirror the responsibilities outlined in `specs/app-web-shell.spec.md`.
  */
-export enum PanelId {
-  Editor = "editor",
-  Preview = "preview",
-  Settings = "settings"
-}
+export const PanelId = {
+  Editor: "editor",
+  Preview: "preview",
+  Settings: "settings"
+} as const;
+
+export type PanelId = (typeof PanelId)[keyof typeof PanelId];
 
 export const PANEL_ORDER: readonly PanelId[] = [PanelId.Editor, PanelId.Preview, PanelId.Settings];
 
@@ -16,26 +18,32 @@ export const PANEL_ORDER: readonly PanelId[] = [PanelId.Editor, PanelId.Preview,
  * - `preview-only`: only the preview should be visible.
  * - `settings`: settings replace the main workspace.
  */
-export enum ViewMode {
-  EditorPreview = "editor-preview",
-  PreviewOnly = "preview-only",
-  Settings = "settings"
-}
+export const ViewMode = {
+  EditorPreview: "editor-preview",
+  PreviewOnly: "preview-only",
+  Settings: "settings"
+} as const;
+
+export type ViewMode = (typeof ViewMode)[keyof typeof ViewMode];
 
 /**
  * Shell layout state derived from viewport size.
  */
-export enum ShellLayout {
-  Desktop = "desktop",
-  Mobile = "mobile"
-}
+export const ShellLayout = {
+  Desktop: "desktop",
+  Mobile: "mobile"
+} as const;
 
-export enum SaveStatusKind {
-  Idle = "idle",
-  Saving = "saving",
-  Saved = "saved",
-  Error = "error"
-}
+export type ShellLayout = (typeof ShellLayout)[keyof typeof ShellLayout];
+
+export const SaveStatusKind = {
+  Idle: "idle",
+  Saving: "saving",
+  Saved: "saved",
+  Error: "error"
+} as const;
+
+export type SaveStatusKind = (typeof SaveStatusKind)[keyof typeof SaveStatusKind];
 
 export type SaveStatus =
   | { kind: SaveStatusKind.Idle; message: "Saved locally \u2713"; timestamp: number | null }

--- a/apps/web/src/lib/stores/storage/types.ts
+++ b/apps/web/src/lib/stores/storage/types.ts
@@ -58,16 +58,20 @@ export type DocumentSnapshot = {
   lastEditedBy?: string;
 };
 
-export enum HistoryScope {
-  Document = "document",
-  Settings = "settings"
-}
+export const HistoryScope = {
+  Document: "document",
+  Settings: "settings"
+} as const;
 
-export enum HistoryOrigin {
-  Keyboard = "keyboard",
-  Toolbar = "toolbar",
-  Api = "api"
-}
+export type HistoryScope = (typeof HistoryScope)[keyof typeof HistoryScope];
+
+export const HistoryOrigin = {
+  Keyboard: "keyboard",
+  Toolbar: "toolbar",
+  Api: "api"
+} as const;
+
+export type HistoryOrigin = (typeof HistoryOrigin)[keyof typeof HistoryOrigin];
 
 export type HistoryEntry = {
   id: string;
@@ -80,20 +84,22 @@ export type HistoryEntry = {
   sequence: number;
 };
 
-export enum AuditEventType {
-  DocumentCreated = "document.created",
-  DocumentUpdated = "document.updated",
-  DocumentDeleted = "document.deleted",
-  DocumentRestored = "document.restored",
-  DocumentReordered = "document.reordered",
-  DocumentPurged = "document.purged",
-  HistoryPruned = "history.pruned",
-  SettingsUpdated = "settings.updated",
-  MigrationCompleted = "migration.completed",
-  StorageReset = "storage.reset",
-  StorageCorruption = "storage.corruption",
-  StorageQuotaWarning = "storage.quota.warning"
-}
+export const AuditEventType = {
+  DocumentCreated: "document.created",
+  DocumentUpdated: "document.updated",
+  DocumentDeleted: "document.deleted",
+  DocumentRestored: "document.restored",
+  DocumentReordered: "document.reordered",
+  DocumentPurged: "document.purged",
+  HistoryPruned: "history.pruned",
+  SettingsUpdated: "settings.updated",
+  MigrationCompleted: "migration.completed",
+  StorageReset: "storage.reset",
+  StorageCorruption: "storage.corruption",
+  StorageQuotaWarning: "storage.quota.warning"
+} as const;
+
+export type AuditEventType = (typeof AuditEventType)[keyof typeof AuditEventType];
 
 export type AuditEntry = {
   id: string;
@@ -122,19 +128,23 @@ export type StorageMutationResult = {
 /**
  * Event payload describing a change broadcast across tabs.
  */
-export enum StorageBroadcastScope {
-  Snapshot = "snapshot",
-  Documents = "documents",
-  Settings = "settings",
-  Config = "config",
-  History = "history",
-  Audit = "audit"
-}
+export const StorageBroadcastScope = {
+  Snapshot: "snapshot",
+  Documents: "documents",
+  Settings: "settings",
+  Config: "config",
+  History: "history",
+  Audit: "audit"
+} as const;
 
-export enum StorageBroadcastOrigin {
-  Local = "local",
-  External = "external"
-}
+export type StorageBroadcastScope = (typeof StorageBroadcastScope)[keyof typeof StorageBroadcastScope];
+
+export const StorageBroadcastOrigin = {
+  Local: "local",
+  External: "external"
+} as const;
+
+export type StorageBroadcastOrigin = (typeof StorageBroadcastOrigin)[keyof typeof StorageBroadcastOrigin];
 
 export type StorageBroadcast = {
   scope: StorageBroadcastScope;

--- a/apps/web/src/lib/stores/theme.ts
+++ b/apps/web/src/lib/stores/theme.ts
@@ -1,10 +1,12 @@
 import { browser } from "$app/environment";
 import { writable } from "svelte/store";
 
-export enum Theme {
-  Light = "light",
-  Dark = "dark"
-}
+export const Theme = {
+  Light: "light",
+  Dark: "dark"
+} as const;
+
+export type Theme = (typeof Theme)[keyof typeof Theme];
 
 const STORAGE_KEY = "kelpie-theme";
 


### PR DESCRIPTION
## Summary
- replace remaining TypeScript enums with const literal objects across the web app
- expose matching union types derived from those literals to preserve type safety

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d71088b34083299c94747330468c79