### PR TITLE
Fix Svelte lint and type issues

### DIFF
--- a/apps/web/e2e/steps/save-indicator.steps.ts
+++ b/apps/web/e2e/steps/save-indicator.steps.ts
@@ -122,7 +122,7 @@ async function setSaveStatus(page: Page, update: SaveStatusUpdate): Promise<void
 
       const baseTimestamp = resolveTimestamp();
 
-      const { Idle, Saving, Saved, Error } = enums as typeof SaveStatusKind;
+      const { Idle, Saving, Saved, Error: ErrorStatus } = enums as typeof SaveStatusKind;
 
       if (kind === Saving) {
         setter({ kind: Saving, message: message ?? "Saving locally…", timestamp: baseTimestamp ?? Date.now() });
@@ -134,8 +134,12 @@ async function setSaveStatus(page: Page, update: SaveStatusUpdate): Promise<void
         return;
       }
 
-      if (kind === Error) {
-        setter({ kind: Error, message: message ?? "Failed to save locally", timestamp: baseTimestamp ?? Date.now() });
+      if (kind === ErrorStatus) {
+        setter({
+          kind: ErrorStatus,
+          message: message ?? "Failed to save locally",
+          timestamp: baseTimestamp ?? Date.now()
+        });
         return;
       }
 
@@ -188,16 +192,22 @@ Then("the tooltip still describes local storage", async ({ page }) => {
 Then("the timestamp is displayed in parentheses with the local time", async ({ page }) => {
   const iso = lastTimestampIso;
   expect(iso).not.toBeNull();
+  if (!iso) {
+    throw new Error("expected timestamp to be recorded");
+  }
 
-  const expectedTime = await page.evaluate((timestamp) => new Date(timestamp).toLocaleTimeString(), iso);
+  const expectedTime = await page.evaluate((timestamp: string) => new Date(timestamp).toLocaleTimeString(), iso);
   await expect(indicatorTimestampLocator(page)).toHaveText(`(${expectedTime})`);
 });
 
 Then("the tooltip includes the last saved time on a new line", async ({ page }) => {
   const iso = lastTimestampIso;
   expect(iso).not.toBeNull();
+  if (!iso) {
+    throw new Error("expected timestamp to be recorded");
+  }
 
-  const formattedTime = await page.evaluate((timestamp) => new Date(timestamp).toLocaleTimeString(), iso);
+  const formattedTime = await page.evaluate((timestamp: string) => new Date(timestamp).toLocaleTimeString(), iso);
   const expectedMessage = `${LOCAL_SAVE_TOOLTIP_MESSAGE}\nLast saved at ${formattedTime}.`;
   await expectTooltipMessage(page, expectedMessage);
 });
@@ -256,7 +266,11 @@ Then("it displays the formatted time in parentheses after the label", async ({ p
   const iso = lastTimestampIso;
   expect(iso).not.toBeNull();
 
-  const expectedTime = await page.evaluate((timestamp) => new Date(timestamp).toLocaleTimeString(), iso);
+  if (!iso) {
+    throw new Error("expected timestamp to be recorded");
+  }
+
+  const expectedTime = await page.evaluate((timestamp: string) => new Date(timestamp).toLocaleTimeString(), iso);
 
   await expect(indicatorTimestampLocator(page)).toHaveText(`(${expectedTime})`);
 });

--- a/apps/web/e2e/types/imports.d.ts
+++ b/apps/web/e2e/types/imports.d.ts
@@ -1,0 +1,4 @@
+declare module "/src/*" {
+  const mod: unknown;
+  export = mod;
+}

--- a/apps/web/src/lib/app-shell/ViewModeToggleButton.test.ts
+++ b/apps/web/src/lib/app-shell/ViewModeToggleButton.test.ts
@@ -4,26 +4,26 @@ import { tick } from "svelte";
 import { get } from "svelte/store";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import ViewModeToggleButton from "./ViewModeToggleButton.svelte";
-import type { ViewMode } from "./contracts";
+import { ShellLayout, ViewMode, type ViewMode as ViewModeType } from "./contracts";
 import { setLayout, setViewMode, shellState } from "$lib/stores/shell";
 
-type ModeExpectation = { id: ViewMode; label: string };
+type ModeExpectation = { id: ViewModeType; label: string };
 
 const modes: ModeExpectation[] = [
-  { id: "editor-preview", label: "Editor & preview" },
-  { id: "preview-only", label: "Preview" },
-  { id: "settings", label: "Settings" }
+  { id: ViewMode.EditorPreview, label: "Editor & preview" },
+  { id: ViewMode.PreviewOnly, label: "Preview" },
+  { id: ViewMode.Settings, label: "Settings" }
 ];
 
 describe("ViewModeToggleButton", () => {
   beforeEach(() => {
-    setLayout("desktop");
-    setViewMode("editor-preview");
+    setLayout(ShellLayout.Desktop);
+    setViewMode(ViewMode.EditorPreview);
   });
 
   afterEach(() => {
-    setLayout("desktop");
-    setViewMode("editor-preview");
+    setLayout(ShellLayout.Desktop);
+    setViewMode(ViewMode.EditorPreview);
   });
 
   it("renders an accessible toggle for each view mode", () => {
@@ -50,7 +50,7 @@ describe("ViewModeToggleButton", () => {
     await tick();
 
     const state = get(shellState);
-    expect(state.viewMode).toBe("preview-only");
+    expect(state.viewMode).toBe(ViewMode.PreviewOnly);
     expect(state.activePanel).toBe("preview");
     expect(previewButton).toHaveAttribute("aria-pressed", "true");
   });
@@ -58,7 +58,7 @@ describe("ViewModeToggleButton", () => {
   it("reflects external view mode changes", async () => {
     render(ViewModeToggleButton);
 
-    setViewMode("settings");
+    setViewMode(ViewMode.Settings);
     await tick();
 
     const settingsButton = screen.getByRole("button", { name: "Settings" });

--- a/apps/web/src/lib/panels/settings/AppSettingsPanel.svelte
+++ b/apps/web/src/lib/panels/settings/AppSettingsPanel.svelte
@@ -1,14 +1,20 @@
 <svelte:options runes={false} />
 
-<script lang="ts">
+<script lang="ts" context="module">
   export type DebounceOption = 125 | 250 | 500 | 750 | 1000;
 
   export interface ShellSettings {
     debounceMs: DebounceOption;
   }
+</script>
+
+<script lang="ts">
+  type ShellSettings = import("./AppSettingsPanel.svelte").ShellSettings;
+
+  const DEFAULT_DEBOUNCE: ShellSettings["debounceMs"] = 250;
 
   export let settings: ShellSettings = {
-    debounceMs: 300 as DebounceOption
+    debounceMs: DEFAULT_DEBOUNCE
   };
 </script>
 

--- a/apps/web/src/lib/stores/state.test.ts
+++ b/apps/web/src/lib/stores/state.test.ts
@@ -19,7 +19,10 @@ function createSnapshot(overrides: Partial<StorageSnapshot> = {}): StorageSnapsh
       historyRetentionDays: 7,
       historyEntryCap: 50,
       auditEntryCap: 20,
-      softDeleteRetentionDays: 7
+      softDeleteRetentionDays: 7,
+      quotaWarningBytes: 5_000,
+      quotaHardLimitBytes: 10_000,
+      gcIdleTriggerMs: 30_000
     },
     settings: {
       lastActiveDocumentId: null,

--- a/apps/web/src/lib/stores/storage/broadcast.test.ts
+++ b/apps/web/src/lib/stores/storage/broadcast.test.ts
@@ -32,7 +32,7 @@ describe("scheduleBroadcast", () => {
     vi.useFakeTimers();
     vi.resetModules();
 
-    const postMessage = vi.fn();
+    const postMessage = vi.fn<(payload: unknown) => void>();
     const close = vi.fn();
 
     class FakeBroadcastChannel {
@@ -73,7 +73,7 @@ describe("scheduleBroadcast", () => {
     vi.useFakeTimers();
     vi.resetModules();
 
-    const postMessage = vi.fn();
+    const postMessage = vi.fn<(payload: unknown) => void>();
 
     class FakeBroadcastChannel {
       name: string;
@@ -151,7 +151,7 @@ describe("scheduleBroadcast", () => {
 
     const storage = createStorageMock();
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const postMessageSpy = vi.fn(() => {
+    const postMessageSpy = vi.fn<(payload: unknown) => never>(() => {
       throw new Error("post failed");
     });
     const close = vi.fn();
@@ -165,7 +165,6 @@ describe("scheduleBroadcast", () => {
 
       postMessage(payload: unknown) {
         postMessageSpy(payload);
-        throw new Error("post failed");
       }
 
       close() {

--- a/apps/web/src/lib/stores/storage/core.ts
+++ b/apps/web/src/lib/stores/storage/core.ts
@@ -18,6 +18,7 @@ import {
 import { normaliseSnapshotForPersistence } from "./garbage-collection";
 import { runMigrations } from "./migrations";
 import {
+  AuditEventType,
   StorageBroadcastOrigin,
   StorageBroadcastScope,
   type HistoryEntry,
@@ -80,7 +81,7 @@ export function createStorageCore(options: StorageCoreOptions): StorageCore {
           metadata.checksum = checksum;
         }
 
-        corruptionAudit = createAuditEntry("storage.corruption", now(), metadata);
+        corruptionAudit = createAuditEntry(AuditEventType.StorageCorruption, now(), metadata);
       }
     }) ?? createInitialSnapshot();
 

--- a/apps/web/src/lib/stores/storage/documents.test.ts
+++ b/apps/web/src/lib/stores/storage/documents.test.ts
@@ -43,6 +43,10 @@ const BASE_DOCUMENTS: Record<string, DocumentSnapshot> = {
   }
 };
 
+const AUDIT_ID_1 = "00000000-0000-4000-8000-000000000001";
+const AUDIT_ID_2 = "00000000-0000-4000-8000-000000000002";
+const AUDIT_ID_3 = "00000000-0000-4000-8000-000000000003";
+
 function createSnapshot(overrides: Partial<StorageSnapshot> = {}): StorageSnapshot {
   const base = createInitialSnapshot();
   return {
@@ -72,7 +76,7 @@ describe("document mutations", () => {
     const snapshot = createSnapshot();
     const now = () => "2024-02-01T00:00:00.000Z";
     const randomUUID = vi.mocked(globalThis.crypto.randomUUID);
-    randomUUID.mockReturnValueOnce("audit-1").mockReturnValueOnce("audit-2");
+    randomUUID.mockReturnValueOnce(AUDIT_ID_1).mockReturnValueOnce(AUDIT_ID_2);
 
     const result = createDocument(snapshot, {
       id: "doc-2",
@@ -100,7 +104,7 @@ describe("document mutations", () => {
     const snapshot = createSnapshot();
     const now = () => "2024-02-02T00:00:00.000Z";
     const randomUUID = vi.mocked(globalThis.crypto.randomUUID);
-    randomUUID.mockReturnValue("audit-1");
+    randomUUID.mockReturnValue(AUDIT_ID_1);
 
     const result = updateDocument(
       snapshot,
@@ -154,7 +158,7 @@ describe("document mutations", () => {
 
     const now = () => "2024-03-01T00:00:00.000Z";
     const randomUUID = vi.mocked(globalThis.crypto.randomUUID);
-    randomUUID.mockReturnValue("audit-1");
+    randomUUID.mockReturnValue(AUDIT_ID_1);
 
     const result = softDeleteDocument(snapshot, "doc-1", { now });
     expect(result.index[0]).toMatchObject({
@@ -186,7 +190,7 @@ describe("document mutations", () => {
 
     const now = () => "2024-02-05T00:00:00.000Z";
     const randomUUID = vi.mocked(globalThis.crypto.randomUUID);
-    randomUUID.mockReturnValue("audit-1");
+    randomUUID.mockReturnValue(AUDIT_ID_1);
 
     const result = restoreDocument(snapshot, "doc-1", { now });
     expect(result.index[0]).toMatchObject({ deletedAt: null, purgeAfter: null, updatedAt: now() });
@@ -226,7 +230,7 @@ describe("document mutations", () => {
 
     const now = () => "2024-03-10T00:00:00.000Z";
     const randomUUID = vi.mocked(globalThis.crypto.randomUUID);
-    randomUUID.mockReturnValue("audit-1");
+    randomUUID.mockReturnValue(AUDIT_ID_1);
 
     const result = reorderDocuments(snapshot, ["doc-2", "doc-1"], { now });
     expect(result.index.map((entry) => entry.id)).toEqual(["doc-2", "doc-1", "doc-3"]);
@@ -244,13 +248,13 @@ describe("document mutations", () => {
       },
       audit: [
         {
-          id: "audit-1",
+          id: AUDIT_ID_1,
           type: AuditEventType.DocumentCreated,
           createdAt: "2024-01-01T00:00:00.000Z",
           metadata: { id: "doc-0" }
         },
         {
-          id: "audit-2",
+          id: AUDIT_ID_2,
           type: AuditEventType.DocumentUpdated,
           createdAt: "2024-01-02T00:00:00.000Z",
           metadata: { id: "doc-1", fields: ["title"] }
@@ -260,7 +264,7 @@ describe("document mutations", () => {
 
     const now = () => "2024-02-10T00:00:00.000Z";
     const randomUUID = vi.mocked(globalThis.crypto.randomUUID);
-    randomUUID.mockReturnValue("audit-3");
+    randomUUID.mockReturnValue(AUDIT_ID_3);
 
     const result = createDocument(snapshot, {
       id: "doc-2",
@@ -270,9 +274,9 @@ describe("document mutations", () => {
     });
 
     expect(result.audit).toHaveLength(2);
-    expect(result.audit[0]?.id).toBe("audit-2");
+    expect(result.audit[0]?.id).toBe(AUDIT_ID_2);
     expect(result.audit[1]).toMatchObject({
-      id: "audit-3",
+      id: AUDIT_ID_3,
       type: AuditEventType.DocumentCreated,
       metadata: { id: "doc-2", title: "Doc three" }
     });

--- a/apps/web/src/lib/stores/storage/driver.test.ts
+++ b/apps/web/src/lib/stores/storage/driver.test.ts
@@ -70,7 +70,9 @@ describe("createLocalStorageDriver", () => {
 
     expect(driver.load({ onCorruption: corruption })).toBeNull();
     expect(corruption).toHaveBeenCalledTimes(1);
-    expect(corruption.mock.calls[0][0]).toMatchObject({ reason: "parse" });
+    const parseCall = corruption.mock.calls[0];
+    expect(parseCall).toBeDefined();
+    expect(parseCall?.[0]).toMatchObject({ reason: "parse" });
     expect(warnSpy).toHaveBeenCalledWith(
       `${STORAGE_LOG_PREFIX}: storage snapshot corruption detected (parse)`,
       expect.any(SyntaxError)
@@ -93,7 +95,9 @@ describe("createLocalStorageDriver", () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     expect(driver.load({ onCorruption: corruption })).toBeNull();
     expect(corruption).toHaveBeenCalledTimes(1);
-    expect(corruption.mock.calls[0][0]).toMatchObject({ reason: "checksum" });
+    const checksumCall = corruption.mock.calls[0];
+    expect(checksumCall).toBeDefined();
+    expect(checksumCall?.[0]).toMatchObject({ reason: "checksum" });
     expect(warnSpy).toHaveBeenCalledWith(
       `${STORAGE_LOG_PREFIX}: storage snapshot corruption detected (checksum)`,
       expect.objectContaining({ reason: "checksum" })
@@ -128,7 +132,10 @@ describe("createLocalStorageDriver", () => {
     const unsubscribe = driver.subscribe(callback);
 
     expect(addEventListener).toHaveBeenCalledWith("storage", expect.any(Function));
-    const handler = addEventListener.mock.calls[0][1] as (event: StorageEvent) => void;
+    const listenerArgs = addEventListener.mock.calls[0];
+    expect(listenerArgs).toBeDefined();
+    const handler = listenerArgs?.[1] as (event: StorageEvent) => void;
+    expect(handler).toBeInstanceOf(Function);
 
     handler(new StorageEvent("storage", { key: "other" }));
     expect(callback).not.toHaveBeenCalled();

--- a/apps/web/src/lib/stores/storage/driver.ts
+++ b/apps/web/src/lib/stores/storage/driver.ts
@@ -45,7 +45,7 @@ export class StorageCorruptionError extends Error {
 }
 
 export class StorageDriverQuotaError extends Error {
-  readonly cause: unknown;
+  override readonly cause: unknown;
 
   constructor(cause: unknown) {
     super("storage quota exceeded");
@@ -192,6 +192,9 @@ export function createLocalStorageDriver(key: string, options: CreateLocalStorag
     const excess = backupKeys.length - backupLimit;
     for (let index = 0; index < excess; index += 1) {
       const keyToRemove = backupKeys[index];
+      if (!keyToRemove) {
+        continue;
+      }
       try {
         storage.removeItem(keyToRemove);
       } catch (error) {

--- a/apps/web/src/lib/stores/storage/history.ts
+++ b/apps/web/src/lib/stores/storage/history.ts
@@ -1,5 +1,6 @@
 import { appendAuditEntries } from "./audit";
 import {
+  AuditEventType,
   HistoryScope,
   type AuditEntry,
   type HistoryEntry,
@@ -322,7 +323,7 @@ function createHistoryAuditEntry(
 ): AuditEntry {
   return {
     id: createId(),
-    type: "history.pruned",
+    type: AuditEventType.HistoryPruned,
     createdAt: nowFn(),
     metadata: {
       count: pruned.length,

--- a/apps/web/src/lib/stores/storage/migrations.test.ts
+++ b/apps/web/src/lib/stores/storage/migrations.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { runMigrations } from "./migrations";
 import type { StorageMigration } from "./migrations";
-import type { StorageSnapshot } from "./types";
+import { AuditEventType, type StorageSnapshot } from "./types";
 
 function createSnapshot(overrides: Partial<StorageSnapshot> = {}): StorageSnapshot {
   const base: StorageSnapshot = {
@@ -84,7 +84,7 @@ describe("runMigrations", () => {
     expect(result.snapshot.config.historyEntryCap).toBe(99);
     expect(result.snapshot.audit).toHaveLength(1);
     expect(result.snapshot.audit[0]).toMatchObject({
-      type: "migration.completed",
+      type: AuditEventType.MigrationCompleted,
       createdAt: now(),
       metadata: {
         from: 0,

--- a/apps/web/src/lib/stores/storage/migrations/index.ts
+++ b/apps/web/src/lib/stores/storage/migrations/index.ts
@@ -1,6 +1,6 @@
 import { appendAuditEntries, createAuditEntry } from "../audit";
 import { STORAGE_SCHEMA_VERSION } from "../constants";
-import type { IsoDateTimeString, StorageSnapshot } from "../types";
+import { AuditEventType, type IsoDateTimeString, type StorageSnapshot } from "../types";
 
 export type StorageMigration = {
   from: number;
@@ -91,7 +91,7 @@ export function runMigrations(
 
   const migratedFrom = String(originalVersion);
   const completedAt = now();
-  const auditEntry = createAuditEntry("migration.completed", completedAt, {
+  const auditEntry = createAuditEntry(AuditEventType.MigrationCompleted, completedAt, {
     from: originalVersion,
     to: targetVersion,
     steps: applied.map((step) => ({ from: step.from, to: step.to }))

--- a/apps/web/src/types/sanitize-html.d.ts
+++ b/apps/web/src/types/sanitize-html.d.ts
@@ -1,0 +1,38 @@
+declare module "sanitize-html" {
+  namespace sanitizeHtml {
+    interface Attributes {
+      [attribute: string]: string | undefined;
+    }
+
+    interface TransformTagsMap {
+      [tagName: string]:
+        | string
+        | ((tagName: string, attribs: Attributes) => { tagName?: string; attribs?: Attributes });
+    }
+
+    interface IOptions {
+      allowedTags?: string[];
+      allowedAttributes?: Record<string, string[]>;
+      allowedSchemes?: string[];
+      allowedSchemesByTag?: Record<string, string[]>;
+      allowedClasses?: Record<string, Array<string | RegExp>>;
+      transformTags?: TransformTagsMap;
+      [key: string]: unknown;
+    }
+
+    type Defaults = IOptions;
+  }
+
+  interface SanitizeHtmlFunction {
+    (html: string, options?: sanitizeHtml.IOptions): string;
+    defaults: sanitizeHtml.Defaults;
+  }
+
+  const sanitizeHtml: SanitizeHtmlFunction;
+
+  export default sanitizeHtml;
+  export type IOptions = sanitizeHtml.IOptions;
+  export type Attributes = sanitizeHtml.Attributes;
+  export type TransformTagsMap = sanitizeHtml.TransformTagsMap;
+  export type Defaults = sanitizeHtml.Defaults;
+}

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -12,7 +12,7 @@
     "noUncheckedIndexedAccess": true,
     "noImplicitOverride": true,
     "moduleResolution": "bundler",
-    "types": ["node", "playwright", "vitest/globals", "@testing-library/jest-dom"]
+    "types": ["@sveltejs/kit", "node", "playwright", "vitest/globals", "@testing-library/jest-dom"]
   },
   "include": ["src", "e2e"]
   // Path aliases are handled by https://svelte.dev/docs/kit/configuration#alias


### PR DESCRIPTION
## Summary
- add local ambient typings to unblock sanitize-html and Vite-style imports
- tighten markdown rendering, storage utilities, and Svelte components to satisfy strict typing
- update associated tests to use typed enums, guards, and UUID formats

## Testing
- pnpm --filter web check
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d70f0552888329a6c405947b07162f