### PR TITLE
Refactor toolbar test id constants into enum

### DIFF
--- a/apps/web/e2e/steps/toolbar.steps.ts
+++ b/apps/web/e2e/steps/toolbar.steps.ts
@@ -4,7 +4,7 @@ import {
   TOOLBAR_BRAND_CLUSTER_CLASSES,
   TOOLBAR_CONTROLS_CLUSTER_CLASSES,
   TOOLBAR_SAVE_INDICATOR_WRAPPER_CLASSES,
-  TOOLBAR_TEST_IDS,
+  ToolbarTestId,
   TOOLBAR_WRAPPER_CLASSES
 } from "../../src/lib/app-shell/toolbar.constants";
 
@@ -51,20 +51,20 @@ Then("the toolbar displays the save indicator component", async ({ page }) => {
 });
 
 Then("the toolbar root uses the exported wrapper classes", async ({ page }) => {
-  const root = page.getByTestId(TOOLBAR_TEST_IDS.root);
+  const root = page.getByTestId(ToolbarTestId.Root);
   await expect(root).toBeVisible();
   await expectLocatorHasClasses(root, TOOLBAR_WRAPPER_CLASSES);
 });
 
 Then("the brand cluster test id is available for instrumentation", async ({ page }) => {
-  await expect(page.getByTestId(TOOLBAR_TEST_IDS.brandCluster)).toBeVisible();
+  await expect(page.getByTestId(ToolbarTestId.BrandCluster)).toBeVisible();
 });
 
 Then("the controls cluster includes the save indicator wrapper and workspace controls", async ({ page }) => {
-  const controlsCluster = page.getByTestId(TOOLBAR_TEST_IDS.controlsCluster);
+  const controlsCluster = page.getByTestId(ToolbarTestId.ControlsCluster);
   await expect(controlsCluster).toBeVisible();
 
-  const saveIndicatorWrapper = controlsCluster.getByTestId(TOOLBAR_TEST_IDS.saveIndicatorWrapper);
+  const saveIndicatorWrapper = controlsCluster.getByTestId(ToolbarTestId.SaveIndicatorWrapper);
   await expect(saveIndicatorWrapper).toBeVisible();
   await expect(saveIndicatorWrapper.getByTestId("save-indicator")).toBeVisible();
 
@@ -73,9 +73,9 @@ Then("the controls cluster includes the save indicator wrapper and workspace con
 });
 
 Then("each cluster reuses the exported layout class tokens", async ({ page }) => {
-  const brandCluster = page.getByTestId(TOOLBAR_TEST_IDS.brandCluster);
-  const controlsCluster = page.getByTestId(TOOLBAR_TEST_IDS.controlsCluster);
-  const saveIndicatorWrapper = page.getByTestId(TOOLBAR_TEST_IDS.saveIndicatorWrapper);
+  const brandCluster = page.getByTestId(ToolbarTestId.BrandCluster);
+  const controlsCluster = page.getByTestId(ToolbarTestId.ControlsCluster);
+  const saveIndicatorWrapper = page.getByTestId(ToolbarTestId.SaveIndicatorWrapper);
 
   await expectLocatorHasClasses(brandCluster, TOOLBAR_BRAND_CLUSTER_CLASSES);
   await expectLocatorHasClasses(controlsCluster, TOOLBAR_CONTROLS_CLUSTER_CLASSES);

--- a/apps/web/src/lib/app-shell/Toolbar.svelte
+++ b/apps/web/src/lib/app-shell/Toolbar.svelte
@@ -10,22 +10,22 @@
     TOOLBAR_BRAND_CLUSTER_CLASSES,
     TOOLBAR_CONTROLS_CLUSTER_CLASSES,
     TOOLBAR_SAVE_INDICATOR_WRAPPER_CLASSES,
-    TOOLBAR_TEST_IDS,
+    ToolbarTestId,
     TOOLBAR_WRAPPER_CLASSES
   } from "./toolbar.constants";
 
   export let version: string;
 </script>
 
-<header class={TOOLBAR_WRAPPER_CLASSES} data-testid={TOOLBAR_TEST_IDS.root}>
-  <div class={TOOLBAR_BRAND_CLUSTER_CLASSES} data-testid={TOOLBAR_TEST_IDS.brandCluster}>
+<header class={TOOLBAR_WRAPPER_CLASSES} data-testid={ToolbarTestId.Root}>
+  <div class={TOOLBAR_BRAND_CLUSTER_CLASSES} data-testid={ToolbarTestId.BrandCluster}>
     <ToolbarBrand {version} />
   </div>
 
-  <div class={TOOLBAR_CONTROLS_CLUSTER_CLASSES} data-testid={TOOLBAR_TEST_IDS.controlsCluster}>
+  <div class={TOOLBAR_CONTROLS_CLUSTER_CLASSES} data-testid={ToolbarTestId.ControlsCluster}>
     <PanelToggleGroup />
 
-    <div class={TOOLBAR_SAVE_INDICATOR_WRAPPER_CLASSES} data-testid={TOOLBAR_TEST_IDS.saveIndicatorWrapper}>
+    <div class={TOOLBAR_SAVE_INDICATOR_WRAPPER_CLASSES} data-testid={ToolbarTestId.SaveIndicatorWrapper}>
       <SaveIndicator />
     </div>
 

--- a/apps/web/src/lib/app-shell/Toolbar.test.ts
+++ b/apps/web/src/lib/app-shell/Toolbar.test.ts
@@ -10,7 +10,7 @@ import {
   TOOLBAR_BRAND_CLUSTER_CLASSES,
   TOOLBAR_CONTROLS_CLUSTER_CLASSES,
   TOOLBAR_SAVE_INDICATOR_WRAPPER_CLASSES,
-  TOOLBAR_TEST_IDS,
+  ToolbarTestId,
   TOOLBAR_WRAPPER_CLASSES
 } from "./toolbar.constants";
 
@@ -53,16 +53,16 @@ describe("Toolbar", () => {
   it("applies exported layout classes and test ids to clusters", () => {
     renderToolbar("2.0.0");
 
-    const root = screen.getByTestId(TOOLBAR_TEST_IDS.root);
+    const root = screen.getByTestId(ToolbarTestId.Root);
     expectElementHasClasses(root as HTMLElement, TOOLBAR_WRAPPER_CLASSES);
 
-    const brandCluster = screen.getByTestId(TOOLBAR_TEST_IDS.brandCluster);
+    const brandCluster = screen.getByTestId(ToolbarTestId.BrandCluster);
     expectElementHasClasses(brandCluster as HTMLElement, TOOLBAR_BRAND_CLUSTER_CLASSES);
 
-    const controlsCluster = screen.getByTestId(TOOLBAR_TEST_IDS.controlsCluster);
+    const controlsCluster = screen.getByTestId(ToolbarTestId.ControlsCluster);
     expectElementHasClasses(controlsCluster as HTMLElement, TOOLBAR_CONTROLS_CLUSTER_CLASSES);
 
-    const saveIndicatorWrapper = screen.getByTestId(TOOLBAR_TEST_IDS.saveIndicatorWrapper);
+    const saveIndicatorWrapper = screen.getByTestId(ToolbarTestId.SaveIndicatorWrapper);
     expectElementHasClasses(saveIndicatorWrapper as HTMLElement, TOOLBAR_SAVE_INDICATOR_WRAPPER_CLASSES);
   });
 

--- a/apps/web/src/lib/app-shell/toolbar.constants.ts
+++ b/apps/web/src/lib/app-shell/toolbar.constants.ts
@@ -1,12 +1,12 @@
 export const BRAND_NAME = "Kelpie";
 export const BRAND_TAGLINE = "Markdown to-do studio — edit, preview, and fine-tune your flow.";
 
-export const TOOLBAR_TEST_IDS = {
-  root: "toolbar",
-  brandCluster: "toolbar-brand-cluster",
-  controlsCluster: "toolbar-controls-cluster",
-  saveIndicatorWrapper: "toolbar-save-indicator-wrapper"
-} as const;
+export enum ToolbarTestId {
+  Root = "toolbar",
+  BrandCluster = "toolbar-brand-cluster",
+  ControlsCluster = "toolbar-controls-cluster",
+  SaveIndicatorWrapper = "toolbar-save-indicator-wrapper"
+}
 
 export const TOOLBAR_WRAPPER_CLASSES =
   "sticky top-0 z-30 flex w-full flex-wrap items-center justify-between gap-3 border-b border-base-300/70 bg-base-100/95 px-3 py-2 backdrop-blur";

--- a/specs/toolbar.spec.md
+++ b/specs/toolbar.spec.md
@@ -125,9 +125,9 @@ the workspace.
 - Layout class tokens and testing IDs are centralized in
   `toolbar.constants.ts`, keeping styling, instrumentation, and tests aligned
   without string duplication inside the Svelte markup. Unit tests import these
-  exported strings directly so assertions never drift from implementation
+  exported identifiers directly so assertions never drift from implementation
   details.
-- `TOOLBAR_TEST_IDS` expose stable selectors so unit tests can target
+- `ToolbarTestId` exposes stable selectors so unit tests can target
   high-level clusters without depending on specific DOM structures. Tests also
   rely on `ShellLayout`, `ViewMode`, and `PanelId` enums when manipulating shell
   stores, eliminating untyped string literals that obscure intent during future


### PR DESCRIPTION
## Summary
- replace the toolbar test id constant map with a string enum to avoid pseudo-enum exports
- update the toolbar component, unit test, and e2e steps to consume the new enum identifiers
- refresh the toolbar specification to mention the new enum-based selectors

## Testing
- `pnpm --filter web exec vitest run src/lib/app-shell/Toolbar.test.ts --environment jsdom`
- `CI=1 pnpm --filter web lint`


------
https://chatgpt.com/codex/tasks/task_e_68d7125f26288329a2a58ab7c961b5e1