### PR TITLE
Fix storage constant exports to restore app rendering

### DIFF
--- a/apps/web/src/lib/stores/storage/core.ts
+++ b/apps/web/src/lib/stores/storage/core.ts
@@ -19,6 +19,7 @@ import { normaliseSnapshotForPersistence } from "./garbage-collection";
 import { runMigrations } from "./migrations";
 import { logStorageMutation, recordCorruption, recordMigrationSummary } from "./instrumentation";
 import { estimateSnapshotSize } from "./size";
+import { StorageBroadcastOrigin, StorageBroadcastScope } from "./types";
 import type {
   HistoryEntry,
   IsoDateTimeString,

--- a/apps/web/src/lib/stores/storage/garbage-collection.ts
+++ b/apps/web/src/lib/stores/storage/garbage-collection.ts
@@ -1,6 +1,7 @@
 import { appendAuditEntries, createAuditEntry } from "./audit";
 import { estimateSnapshotSize } from "./size";
 import { recordQuotaWarning } from "./instrumentation";
+import { AuditEventType, HistoryScope } from "./types";
 import type { AuditEntry, HistoryEntry, IsoDateTimeString, StorageSnapshot } from "./types";
 
 export class StorageQuotaError extends Error {

--- a/apps/web/src/lib/stores/storage/types.ts
+++ b/apps/web/src/lib/stores/storage/types.ts
@@ -82,21 +82,24 @@ export type HistoryEntry = {
   sequence: number;
 };
 
-export type AuditEventType =
-  | "document.created"
-  | "document.updated"
-  | "document.deleted"
-  | "document.restored"
-  | "document.reordered"
-  | "document.purged"
-  | "history.pruned"
-  | "settings.updated"
-  | "migration.completed"
-  | "storage.reset"
-  | "storage.simulatedFirstRun"
-  | "storage.gc.run"
-  | "storage.corruption"
-  | "storage.quota.warning";
+export const AuditEventType = {
+  DocumentCreated: "document.created",
+  DocumentUpdated: "document.updated",
+  DocumentDeleted: "document.deleted",
+  DocumentRestored: "document.restored",
+  DocumentReordered: "document.reordered",
+  DocumentPurged: "document.purged",
+  HistoryPruned: "history.pruned",
+  SettingsUpdated: "settings.updated",
+  MigrationCompleted: "migration.completed",
+  StorageReset: "storage.reset",
+  StorageSimulatedFirstRun: "storage.simulatedFirstRun",
+  StorageGarbageCollectionRun: "storage.gc.run",
+  StorageCorruption: "storage.corruption",
+  StorageQuotaWarning: "storage.quota.warning"
+} as const;
+
+export type AuditEventType = (typeof AuditEventType)[keyof typeof AuditEventType];
 
 export type AuditEntry = {
   id: string;
@@ -125,19 +128,23 @@ export type StorageMutationResult = {
 /**
  * Event payload describing a change broadcast across tabs.
  */
-export enum StorageBroadcastScope {
-  Snapshot = "snapshot",
-  Documents = "documents",
-  Settings = "settings",
-  Config = "config",
-  History = "history",
-  Audit = "audit"
-}
+export const StorageBroadcastScope = {
+  Snapshot: "snapshot",
+  Documents: "documents",
+  Settings: "settings",
+  Config: "config",
+  History: "history",
+  Audit: "audit"
+} as const;
 
-export enum StorageBroadcastOrigin {
-  Local = "local",
-  External = "external"
-}
+export type StorageBroadcastScope = (typeof StorageBroadcastScope)[keyof typeof StorageBroadcastScope];
+
+export const StorageBroadcastOrigin = {
+  Local: "local",
+  External: "external"
+} as const;
+
+export type StorageBroadcastOrigin = (typeof StorageBroadcastOrigin)[keyof typeof StorageBroadcastOrigin];
 
 export type StorageBroadcast = {
   scope: StorageBroadcastScope;


### PR DESCRIPTION
## Summary
- convert storage audit event and broadcast identifiers into exported constant objects that are usable at runtime
- import the broadcast constants inside the storage core to send notifications reliably
- wire garbage collection to the shared audit and history constants so quota handling works in the browser

## Testing
- pnpm --filter web test:unit

------
https://chatgpt.com/codex/tasks/task_e_68d711c7084c8329887b11f8930740d6