### PR TITLE
Fix storage typing and lint issues

### DIFF
--- a/apps/web/e2e/broadcast.test.ts
+++ b/apps/web/e2e/broadcast.test.ts
@@ -27,7 +27,10 @@ test.describe("storage broadcast propagation", () => {
       });
 
       await sender.evaluate(async () => {
-        const { scheduleBroadcast } = await import("/src/lib/stores/storage/broadcast.ts");
+        const modulePath = "/src/lib/stores/storage/broadcast.ts";
+        const { scheduleBroadcast } = (await import(/* @vite-ignore */ modulePath)) as {
+          scheduleBroadcast: (broadcast: unknown) => void;
+        };
         scheduleBroadcast({
           scope: "settings",
           updatedAt: "2024-02-01T00:00:00.000Z",
@@ -85,7 +88,10 @@ test.describe("storage broadcast propagation", () => {
       });
 
       await sender.evaluate(async () => {
-        const { scheduleBroadcast } = await import("/src/lib/stores/storage/broadcast.ts");
+        const modulePath = "/src/lib/stores/storage/broadcast.ts";
+        const { scheduleBroadcast } = (await import(/* @vite-ignore */ modulePath)) as {
+          scheduleBroadcast: (broadcast: unknown) => void;
+        };
         scheduleBroadcast({
           scope: "history",
           updatedAt: "2024-02-02T00:00:00.000Z",

--- a/apps/web/src/app.d.ts
+++ b/apps/web/src/app.d.ts
@@ -11,3 +11,8 @@ declare global {
 }
 
 export {};
+
+declare module "/src/*" {
+  const mod: Record<string, unknown>;
+  export = mod;
+}

--- a/apps/web/src/lib/app-shell/ViewModeToggleButton.test.ts
+++ b/apps/web/src/lib/app-shell/ViewModeToggleButton.test.ts
@@ -4,26 +4,26 @@ import { tick } from "svelte";
 import { get } from "svelte/store";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import ViewModeToggleButton from "./ViewModeToggleButton.svelte";
-import type { ViewMode } from "./contracts";
+import { PanelId, ShellLayout, ViewMode } from "./contracts";
 import { setLayout, setViewMode, shellState } from "$lib/stores/shell";
 
 type ModeExpectation = { id: ViewMode; label: string };
 
 const modes: ModeExpectation[] = [
-  { id: "editor-preview", label: "Editor & preview" },
-  { id: "preview-only", label: "Preview" },
-  { id: "settings", label: "Settings" }
+  { id: ViewMode.EditorPreview, label: "Editor & preview" },
+  { id: ViewMode.PreviewOnly, label: "Preview" },
+  { id: ViewMode.Settings, label: "Settings" }
 ];
 
 describe("ViewModeToggleButton", () => {
   beforeEach(() => {
-    setLayout("desktop");
-    setViewMode("editor-preview");
+    setLayout(ShellLayout.Desktop);
+    setViewMode(ViewMode.EditorPreview);
   });
 
   afterEach(() => {
-    setLayout("desktop");
-    setViewMode("editor-preview");
+    setLayout(ShellLayout.Desktop);
+    setViewMode(ViewMode.EditorPreview);
   });
 
   it("renders an accessible toggle for each view mode", () => {
@@ -50,15 +50,15 @@ describe("ViewModeToggleButton", () => {
     await tick();
 
     const state = get(shellState);
-    expect(state.viewMode).toBe("preview-only");
-    expect(state.activePanel).toBe("preview");
+    expect(state.viewMode).toBe(ViewMode.PreviewOnly);
+    expect(state.activePanel).toBe(PanelId.Preview);
     expect(previewButton).toHaveAttribute("aria-pressed", "true");
   });
 
   it("reflects external view mode changes", async () => {
     render(ViewModeToggleButton);
 
-    setViewMode("settings");
+    setViewMode(ViewMode.Settings);
     await tick();
 
     const settingsButton = screen.getByRole("button", { name: "Settings" });

--- a/apps/web/src/lib/components/storage/StorageInspector.svelte
+++ b/apps/web/src/lib/components/storage/StorageInspector.svelte
@@ -57,10 +57,9 @@
   function matchesAudit(entry: AuditEntry, query: string): boolean {
     if (!query) return true;
     const normalised = query.toLowerCase();
-    return (
-      entry.type.toLowerCase().includes(normalised) ||
-      (entry.metadata && JSON.stringify(entry.metadata).toLowerCase().includes(normalised))
-    );
+    const metadataMatches =
+      entry.metadata !== undefined && JSON.stringify(entry.metadata).toLowerCase().includes(normalised);
+    return entry.type.toLowerCase().includes(normalised) || metadataMatches;
   }
 
   function resetStorage(): void {
@@ -152,7 +151,10 @@
           <ul class="flex-1 space-y-1 overflow-y-auto px-4 py-3 text-xs">
             {#each $snapshotStore.index
               .map((entry) => $snapshotStore.documents[entry.id])
-              .filter((doc): doc is DocumentSnapshot => Boolean(doc) && matchesDocument(doc, documentQuery))
+              .filter((doc): doc is DocumentSnapshot => {
+                if (!doc) return false;
+                return matchesDocument(doc, documentQuery);
+              })
               .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt)) as document (document.id)}
               <li class="rounded-lg border border-base-300/50 bg-base-200/40 px-3 py-2">
                 <p class="font-semibold text-base-content">{document.title || "Untitled"}</p>

--- a/apps/web/src/lib/panels/settings/AppSettingsPanel.svelte
+++ b/apps/web/src/lib/panels/settings/AppSettingsPanel.svelte
@@ -1,13 +1,15 @@
 <svelte:options runes={false} />
 
-<script lang="ts">
-  import StorageInspector from "$lib/components/storage/StorageInspector.svelte";
-
+<script lang="ts" context="module">
   export type DebounceOption = 125 | 250 | 500 | 750 | 1000;
 
   export interface ShellSettings {
     debounceMs: DebounceOption;
   }
+</script>
+
+<script lang="ts">
+  import StorageInspector from "$lib/components/storage/StorageInspector.svelte";
 
   export let settings: ShellSettings = {
     debounceMs: 300 as DebounceOption

--- a/apps/web/src/lib/stores/storage/audit.test.ts
+++ b/apps/web/src/lib/stores/storage/audit.test.ts
@@ -2,7 +2,14 @@ import { describe, expect, it } from "vitest";
 import { appendAuditEntries, createAuditEntry } from "./audit";
 import type { StorageSnapshot } from "./types";
 
-function createSnapshot(overrides: Partial<StorageSnapshot> = {}): StorageSnapshot {
+type SnapshotOverrides = Partial<Omit<StorageSnapshot, "config" | "settings" | "audit" | "meta">> & {
+  meta?: Partial<StorageSnapshot["meta"]>;
+  config?: Partial<StorageSnapshot["config"]>;
+  settings?: Partial<StorageSnapshot["settings"]>;
+  audit?: StorageSnapshot["audit"];
+};
+
+function createSnapshot(overrides: SnapshotOverrides = {}): StorageSnapshot {
   const base: StorageSnapshot = {
     meta: {
       version: 1,
@@ -36,11 +43,15 @@ function createSnapshot(overrides: Partial<StorageSnapshot> = {}): StorageSnapsh
     audit: []
   };
 
+  const { config, settings, meta, audit, ...rest } = overrides;
+
   return {
     ...base,
-    ...overrides,
-    config: { ...base.config, ...(overrides.config ?? {}) },
-    audit: overrides.audit ?? base.audit
+    ...rest,
+    meta: { ...base.meta, ...(meta ?? {}) },
+    config: { ...base.config, ...(config ?? {}) },
+    settings: { ...base.settings, ...(settings ?? {}) },
+    audit: audit ?? base.audit
   } satisfies StorageSnapshot;
 }
 

--- a/apps/web/src/lib/stores/storage/documents.test.ts
+++ b/apps/web/src/lib/stores/storage/documents.test.ts
@@ -74,7 +74,9 @@ describe("document mutations", () => {
     const snapshot = createSnapshot();
     const now = () => "2024-02-01T00:00:00.000Z";
     const randomUUID = vi.mocked(globalThis.crypto.randomUUID);
-    randomUUID.mockReturnValueOnce("audit-1").mockReturnValueOnce("audit-2");
+    randomUUID
+      .mockReturnValueOnce("00000000-0000-0000-0000-000000000001")
+      .mockReturnValueOnce("00000000-0000-0000-0000-000000000002");
 
     const result = createDocument(snapshot, {
       id: "doc-2",
@@ -102,7 +104,7 @@ describe("document mutations", () => {
     const snapshot = createSnapshot();
     const now = () => "2024-02-02T00:00:00.000Z";
     const randomUUID = vi.mocked(globalThis.crypto.randomUUID);
-    randomUUID.mockReturnValue("audit-1");
+    randomUUID.mockReturnValue("00000000-0000-0000-0000-000000000001");
 
     const result = updateDocument(
       snapshot,
@@ -156,7 +158,7 @@ describe("document mutations", () => {
 
     const now = () => "2024-03-01T00:00:00.000Z";
     const randomUUID = vi.mocked(globalThis.crypto.randomUUID);
-    randomUUID.mockReturnValue("audit-1");
+    randomUUID.mockReturnValue("00000000-0000-0000-0000-000000000001");
 
     const result = softDeleteDocument(snapshot, "doc-1", { now });
     expect(result.index[0]).toMatchObject({
@@ -188,7 +190,7 @@ describe("document mutations", () => {
 
     const now = () => "2024-02-05T00:00:00.000Z";
     const randomUUID = vi.mocked(globalThis.crypto.randomUUID);
-    randomUUID.mockReturnValue("audit-1");
+    randomUUID.mockReturnValue("00000000-0000-0000-0000-000000000001");
 
     const result = restoreDocument(snapshot, "doc-1", { now });
     expect(result.index[0]).toMatchObject({ deletedAt: null, purgeAfter: null, updatedAt: now() });
@@ -228,7 +230,7 @@ describe("document mutations", () => {
 
     const now = () => "2024-03-10T00:00:00.000Z";
     const randomUUID = vi.mocked(globalThis.crypto.randomUUID);
-    randomUUID.mockReturnValue("audit-1");
+    randomUUID.mockReturnValue("00000000-0000-0000-0000-000000000001");
 
     const result = reorderDocuments(snapshot, ["doc-2", "doc-1"], { now });
     expect(result.index.map((entry) => entry.id)).toEqual(["doc-2", "doc-1", "doc-3"]);
@@ -262,7 +264,7 @@ describe("document mutations", () => {
 
     const now = () => "2024-02-10T00:00:00.000Z";
     const randomUUID = vi.mocked(globalThis.crypto.randomUUID);
-    randomUUID.mockReturnValue("audit-3");
+    randomUUID.mockReturnValue("00000000-0000-0000-0000-000000000003");
 
     const result = createDocument(snapshot, {
       id: "doc-2",

--- a/apps/web/src/lib/stores/storage/driver.test.ts
+++ b/apps/web/src/lib/stores/storage/driver.test.ts
@@ -72,7 +72,10 @@ describe("createLocalStorageDriver", () => {
 
     expect(driver.load({ onCorruption: corruption })).toBeNull();
     expect(corruption).toHaveBeenCalledTimes(1);
-    expect(corruption.mock.calls[0][0]).toMatchObject({ reason: "parse" });
+    const firstCorruptionCall = corruption.mock.calls[0];
+    expect(firstCorruptionCall).toBeDefined();
+    const [parseError] = firstCorruptionCall ?? [];
+    expect(parseError).toMatchObject({ reason: "parse" });
     expect(warnSpy).toHaveBeenCalledWith(
       `${STORAGE_LOG_PREFIX}: storage snapshot corruption detected (parse)`,
       expect.any(SyntaxError)
@@ -95,7 +98,10 @@ describe("createLocalStorageDriver", () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     expect(driver.load({ onCorruption: corruption })).toBeNull();
     expect(corruption).toHaveBeenCalledTimes(1);
-    expect(corruption.mock.calls[0][0]).toMatchObject({ reason: "checksum" });
+    const checksumCall = corruption.mock.calls[0];
+    expect(checksumCall).toBeDefined();
+    const [checksumError] = checksumCall ?? [];
+    expect(checksumError).toMatchObject({ reason: "checksum" });
     expect(warnSpy).toHaveBeenCalledWith(
       `${STORAGE_LOG_PREFIX}: storage snapshot corruption detected (checksum)`,
       expect.objectContaining({ reason: "checksum" })
@@ -130,7 +136,9 @@ describe("createLocalStorageDriver", () => {
     const unsubscribe = driver.subscribe(callback);
 
     expect(addEventListener).toHaveBeenCalledWith("storage", expect.any(Function));
-    const handler = addEventListener.mock.calls[0][1] as (event: StorageEvent) => void;
+    const firstCall = addEventListener.mock.calls[0];
+    expect(firstCall).toBeDefined();
+    const handler = (firstCall?.[1] as (event: StorageEvent) => void) ?? (() => {});
 
     handler(new StorageEvent("storage", { key: "other" }));
     expect(callback).not.toHaveBeenCalled();

--- a/apps/web/src/lib/stores/storage/driver.ts
+++ b/apps/web/src/lib/stores/storage/driver.ts
@@ -47,12 +47,9 @@ export class StorageCorruptionError extends Error {
 }
 
 export class StorageDriverQuotaError extends Error {
-  readonly cause: unknown;
-
   constructor(cause: unknown) {
-    super("storage quota exceeded");
+    super("storage quota exceeded", { cause });
     this.name = "StorageQuotaError";
-    this.cause = cause;
   }
 }
 
@@ -196,6 +193,9 @@ export function createLocalStorageDriver(key: string, options: CreateLocalStorag
     const excess = backupKeys.length - backupLimit;
     for (let index = 0; index < excess; index += 1) {
       const keyToRemove = backupKeys[index];
+      if (!keyToRemove) {
+        continue;
+      }
       try {
         storage.removeItem(keyToRemove);
       } catch (error) {

--- a/apps/web/src/lib/stores/storage/garbage-collection.ts
+++ b/apps/web/src/lib/stores/storage/garbage-collection.ts
@@ -1,7 +1,14 @@
 import { appendAuditEntries, createAuditEntry } from "./audit";
 import { estimateSnapshotSize } from "./size";
 import { recordQuotaWarning } from "./instrumentation";
-import type { AuditEntry, HistoryEntry, IsoDateTimeString, StorageSnapshot } from "./types";
+import {
+  AuditEventType,
+  HistoryScope,
+  type AuditEntry,
+  type HistoryEntry,
+  type IsoDateTimeString,
+  type StorageSnapshot
+} from "./types";
 
 export class StorageQuotaError extends Error {
   readonly attemptedSize: number;

--- a/apps/web/src/lib/stores/storage/types.ts
+++ b/apps/web/src/lib/stores/storage/types.ts
@@ -82,21 +82,24 @@ export type HistoryEntry = {
   sequence: number;
 };
 
-export type AuditEventType =
-  | "document.created"
-  | "document.updated"
-  | "document.deleted"
-  | "document.restored"
-  | "document.reordered"
-  | "document.purged"
-  | "history.pruned"
-  | "settings.updated"
-  | "migration.completed"
-  | "storage.reset"
-  | "storage.simulatedFirstRun"
-  | "storage.gc.run"
-  | "storage.corruption"
-  | "storage.quota.warning";
+export const AuditEventType = {
+  DocumentCreated: "document.created",
+  DocumentUpdated: "document.updated",
+  DocumentDeleted: "document.deleted",
+  DocumentRestored: "document.restored",
+  DocumentReordered: "document.reordered",
+  DocumentPurged: "document.purged",
+  HistoryPruned: "history.pruned",
+  SettingsUpdated: "settings.updated",
+  MigrationCompleted: "migration.completed",
+  StorageReset: "storage.reset",
+  StorageSimulatedFirstRun: "storage.simulatedFirstRun",
+  StorageGarbageCollection: "storage.gc.run",
+  StorageCorruption: "storage.corruption",
+  StorageQuotaWarning: "storage.quota.warning"
+} as const;
+
+export type AuditEventType = (typeof AuditEventType)[keyof typeof AuditEventType];
 
 export type AuditEntry = {
   id: string;

--- a/apps/web/src/lib/types/sanitize-html.d.ts
+++ b/apps/web/src/lib/types/sanitize-html.d.ts
@@ -1,0 +1,35 @@
+declare module "sanitize-html" {
+  export interface Attributes {
+    [attribute: string]: string | undefined;
+  }
+
+  export interface TransformTagResult {
+    tagName: string;
+    attribs: Attributes;
+  }
+
+  export type TransformTag = (tagName: string, attribs: Attributes) => TransformTagResult;
+
+  export interface TransformTags {
+    [tagName: string]: TransformTag | string | undefined;
+  }
+
+  export interface IOptions {
+    allowedTags?: (string | RegExp)[];
+    allowedAttributes?: Record<string, (string | RegExp)[]>;
+    allowedSchemes?: string[];
+    allowedSchemesByTag?: Record<string, string[]>;
+    allowedClasses?: Record<string, (string | RegExp)[]>;
+    transformTags?: TransformTags;
+    [key: string]: unknown;
+  }
+
+  export interface SanitizeHtml {
+    (input: string, options?: IOptions): string;
+    defaults: IOptions;
+  }
+
+  const sanitizeHtml: SanitizeHtml;
+
+  export default sanitizeHtml;
+}

--- a/apps/web/src/lib/utils/renderMarkdown.ts
+++ b/apps/web/src/lib/utils/renderMarkdown.ts
@@ -1,18 +1,20 @@
-import { Marked } from "marked";
-import sanitizeHtml from "sanitize-html";
+import { Marked, type MarkedOptions } from "marked";
+import sanitizeHtml, { type Attributes, type IOptions } from "sanitize-html";
 
-const markdownParser = new Marked({
+const markdownParser = new Marked();
+
+const markdownOptions: MarkedOptions = {
   gfm: true,
-  breaks: true,
-  headerIds: false,
-  mangle: false
-});
+  breaks: true
+};
+
+markdownParser.setOptions(markdownOptions);
 
 const sanitizeDefaults = sanitizeHtml.defaults;
 
 const allowedTags = Array.from(new Set([...(sanitizeDefaults.allowedTags ?? []), "img", "input"]));
 
-const allowedAttributes: sanitizeHtml.IOptions["allowedAttributes"] = {
+const allowedAttributes: IOptions["allowedAttributes"] = {
   ...sanitizeDefaults.allowedAttributes,
   a: ["href", "name", "target", "rel", "title"],
   code: ["class"],
@@ -36,7 +38,7 @@ const allowedClasses = {
   pre: [...(baseAllowedClasses.pre ?? []), /^language-/]
 };
 
-const sanitizeOptions: sanitizeHtml.IOptions = {
+const sanitizeOptions: IOptions = {
   ...sanitizeDefaults,
   allowedTags,
   allowedAttributes,
@@ -45,22 +47,26 @@ const sanitizeOptions: sanitizeHtml.IOptions = {
   allowedClasses,
   transformTags: {
     ...sanitizeDefaults.transformTags,
-    a: (tagName, attribs) => ({
-      tagName,
-      attribs: {
-        ...attribs,
-        target: attribs.target ?? "_blank",
-        rel: attribs.rel ?? "noreferrer noopener"
-      }
-    }),
-    img: (tagName, attribs) => ({
-      tagName,
-      attribs: {
-        ...attribs,
-        loading: attribs.loading ?? "lazy",
-        decoding: attribs.decoding ?? "async"
-      }
-    })
+    a(tagName: string, attribs: Attributes) {
+      return {
+        tagName,
+        attribs: {
+          ...attribs,
+          target: attribs.target ?? "_blank",
+          rel: attribs.rel ?? "noreferrer noopener"
+        }
+      };
+    },
+    img(tagName: string, attribs: Attributes) {
+      return {
+        tagName,
+        attribs: {
+          ...attribs,
+          loading: attribs.loading ?? "lazy",
+          decoding: attribs.decoding ?? "async"
+        }
+      };
+    }
   }
 };
 

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -12,7 +12,7 @@
     "noUncheckedIndexedAccess": true,
     "noImplicitOverride": true,
     "moduleResolution": "bundler",
-    "types": ["node", "playwright", "vitest/globals", "@testing-library/jest-dom"]
+    "types": ["svelte", "@sveltejs/kit", "node", "playwright", "vitest/globals", "@testing-library/jest-dom"]
   },
   "include": ["src", "e2e"]
   // Path aliases are handled by https://svelte.dev/docs/kit/configuration#alias


### PR DESCRIPTION
## Summary
- add local sanitize-html type declarations and update the markdown renderer to use typed options
- treat audit event identifiers as runtime constants and update storage utilities and tests accordingly
- tighten tests and e2e steps with stronger enum usage and null guards to satisfy strict linting and type checks

## Testing
- pnpm lint
- pnpm typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d7119835848329886bf5d6be4d4926