### PR TITLE
Fix storage type warnings and tighten linting

### DIFF
--- a/apps/web/e2e/broadcast.test.ts
+++ b/apps/web/e2e/broadcast.test.ts
@@ -1,5 +1,7 @@
 import { expect, test } from "@playwright/test";
 
+type BroadcastModule = typeof import("../src/lib/stores/storage/broadcast");
+
 test.describe("storage broadcast propagation", () => {
   test("delivers payloads through BroadcastChannel", async ({ browser }) => {
     const context = await browser.newContext();
@@ -27,7 +29,8 @@ test.describe("storage broadcast propagation", () => {
       });
 
       await sender.evaluate(async () => {
-        const { scheduleBroadcast } = await import("/src/lib/stores/storage/broadcast.ts");
+        const module = (await import("/src/lib/stores/storage/broadcast.ts")) as unknown as BroadcastModule;
+        const { scheduleBroadcast } = module;
         scheduleBroadcast({
           scope: "settings",
           updatedAt: "2024-02-01T00:00:00.000Z",
@@ -85,7 +88,8 @@ test.describe("storage broadcast propagation", () => {
       });
 
       await sender.evaluate(async () => {
-        const { scheduleBroadcast } = await import("/src/lib/stores/storage/broadcast.ts");
+        const module = (await import("/src/lib/stores/storage/broadcast.ts")) as unknown as BroadcastModule;
+        const { scheduleBroadcast } = module;
         scheduleBroadcast({
           scope: "history",
           updatedAt: "2024-02-02T00:00:00.000Z",

--- a/apps/web/src/lib/app-shell/contracts.ts
+++ b/apps/web/src/lib/app-shell/contracts.ts
@@ -36,14 +36,12 @@ export const ShellLayout = {
 
 export type ShellLayout = (typeof ShellLayout)[keyof typeof ShellLayout];
 
-export const SaveStatusKind = {
-  Idle: "idle",
-  Saving: "saving",
-  Saved: "saved",
-  Error: "error"
-} as const;
-
-export type SaveStatusKind = (typeof SaveStatusKind)[keyof typeof SaveStatusKind];
+export enum SaveStatusKind {
+  Idle = "idle",
+  Saving = "saving",
+  Saved = "saved",
+  Error = "error"
+}
 
 export type SaveStatus =
   | { kind: SaveStatusKind.Idle; message: "Saved locally \u2713"; timestamp: number | null }

--- a/apps/web/src/lib/app-shell/save-indicator.config.ts
+++ b/apps/web/src/lib/app-shell/save-indicator.config.ts
@@ -18,9 +18,7 @@ export const LOCAL_SAVE_TOOLTIP =
 export const ERROR_TOOLTIP =
   "We couldn't save locally. Retry or export your data to keep a copy while we work on cloud sync.";
 
-export const DEFAULT_KIND = SaveStatusKind.Saved;
-
-export const SAVE_INDICATOR_CONFIG: Record<SaveStatus["kind"], SaveIndicatorView> = {
+export const SAVE_INDICATOR_CONFIG = {
   [SaveStatusKind.Idle]: {
     tone: {
       badge: "border-success/40 bg-success/10 text-success",
@@ -49,9 +47,12 @@ export const SAVE_INDICATOR_CONFIG: Record<SaveStatus["kind"], SaveIndicatorView
     },
     tooltip: ERROR_TOOLTIP
   }
-};
+} satisfies Record<SaveStatus["kind"], SaveIndicatorView>;
 
-const getConfigFor = (kind: SaveStatus["kind"]) => SAVE_INDICATOR_CONFIG[kind] ?? SAVE_INDICATOR_CONFIG[DEFAULT_KIND];
+export const DEFAULT_KIND: SaveStatus["kind"] = SaveStatusKind.Saved;
+
+const getConfigFor = (kind: SaveStatus["kind"]): SaveIndicatorView =>
+  SAVE_INDICATOR_CONFIG[kind] ?? SAVE_INDICATOR_CONFIG[DEFAULT_KIND];
 
 export const toneFor = (kind: SaveStatus["kind"]) => getConfigFor(kind).tone;
 export const tooltipFor = (kind: SaveStatus["kind"]) => getConfigFor(kind).tooltip;

--- a/apps/web/src/lib/components/storage/StorageInspector.svelte
+++ b/apps/web/src/lib/components/storage/StorageInspector.svelte
@@ -59,7 +59,7 @@
     const normalised = query.toLowerCase();
     return (
       entry.type.toLowerCase().includes(normalised) ||
-      (entry.metadata && JSON.stringify(entry.metadata).toLowerCase().includes(normalised))
+      (entry.metadata != null && JSON.stringify(entry.metadata).toLowerCase().includes(normalised))
     );
   }
 
@@ -152,7 +152,7 @@
           <ul class="flex-1 space-y-1 overflow-y-auto px-4 py-3 text-xs">
             {#each $snapshotStore.index
               .map((entry) => $snapshotStore.documents[entry.id])
-              .filter((doc): doc is DocumentSnapshot => Boolean(doc) && matchesDocument(doc, documentQuery))
+              .filter((doc): doc is DocumentSnapshot => doc !== undefined && matchesDocument(doc, documentQuery))
               .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt)) as document (document.id)}
               <li class="rounded-lg border border-base-300/50 bg-base-200/40 px-3 py-2">
                 <p class="font-semibold text-base-content">{document.title || "Untitled"}</p>

--- a/apps/web/src/lib/stores/storage/audit.test.ts
+++ b/apps/web/src/lib/stores/storage/audit.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it } from "vitest";
 import { appendAuditEntries, createAuditEntry } from "./audit";
 import type { StorageSnapshot } from "./types";
 
-function createSnapshot(overrides: Partial<StorageSnapshot> = {}): StorageSnapshot {
+type SnapshotOverrides = Partial<Omit<StorageSnapshot, "config">> & {
+  config?: Partial<StorageSnapshot["config"]>;
+};
+
+function createSnapshot(overrides: SnapshotOverrides = {}): StorageSnapshot {
   const base: StorageSnapshot = {
     meta: {
       version: 1,

--- a/apps/web/src/lib/stores/storage/core.ts
+++ b/apps/web/src/lib/stores/storage/core.ts
@@ -17,6 +17,7 @@ import {
 } from "./history";
 import { normaliseSnapshotForPersistence } from "./garbage-collection";
 import { runMigrations } from "./migrations";
+import { logStorageMutation, recordCorruption, recordMigrationSummary } from "./instrumentation";
 import {
   AuditEventType,
   StorageBroadcastOrigin,
@@ -28,6 +29,7 @@ import {
   type StorageSnapshot,
   type UiSettings
 } from "./types";
+import { estimateSnapshotSize } from "./size";
 
 export type StorageCoreState = {
   snapshot: StorageSnapshot;
@@ -233,7 +235,7 @@ export function createStorageCore(options: StorageCoreOptions): StorageCore {
 
     const annotated = {
       ...seeded,
-      audit: appendAuditEntries(seeded, createAuditEntry("storage.simulatedFirstRun", timestamp))
+      audit: appendAuditEntries(seeded, createAuditEntry(AuditEventType.StorageSimulatedFirstRun, timestamp))
     } satisfies StorageSnapshot;
 
     applySnapshot(annotated, { persist: true, emitBroadcast: true, label: "storage.simulatedFirstRun" });

--- a/apps/web/src/lib/stores/storage/garbage-collection.ts
+++ b/apps/web/src/lib/stores/storage/garbage-collection.ts
@@ -1,7 +1,14 @@
 import { appendAuditEntries, createAuditEntry } from "./audit";
 import { estimateSnapshotSize } from "./size";
 import { recordQuotaWarning } from "./instrumentation";
-import type { AuditEntry, HistoryEntry, IsoDateTimeString, StorageSnapshot } from "./types";
+import {
+  AuditEventType,
+  HistoryScope,
+  type AuditEntry,
+  type HistoryEntry,
+  type IsoDateTimeString,
+  type StorageSnapshot
+} from "./types";
 
 export class StorageQuotaError extends Error {
   readonly attemptedSize: number;

--- a/apps/web/src/lib/stores/storage/types.ts
+++ b/apps/web/src/lib/stores/storage/types.ts
@@ -98,7 +98,8 @@ export const AuditEventType = {
   MigrationCompleted: "migration.completed",
   StorageReset: "storage.reset",
   StorageCorruption: "storage.corruption",
-  StorageQuotaWarning: "storage.quota.warning"
+  StorageQuotaWarning: "storage.quota.warning",
+  StorageSimulatedFirstRun: "storage.simulatedFirstRun"
 } as const;
 
 export type AuditEventType = (typeof AuditEventType)[keyof typeof AuditEventType];


### PR DESCRIPTION
## Summary
- convert the save status constants to a string enum and tighten the save-indicator configuration helpers
- restore missing storage instrumentation imports, audit event typing, and garbage-collection dependencies to satisfy the type checker
- refine storage inspector narrowing and broadcast test module typing to eliminate outstanding warnings

## Testing
- pnpm --filter web exec prettier --check e2e/broadcast.test.ts src/lib/app-shell/contracts.ts src/lib/app-shell/save-indicator.config.ts src/lib/components/storage/StorageInspector.svelte src/lib/stores/storage/audit.test.ts src/lib/stores/storage/core.ts src/lib/stores/storage/garbage-collection.ts src/lib/stores/storage/types.ts
- pnpm --filter web exec eslint . --max-warnings=0 --no-error-on-unmatched-pattern --color false
- pnpm typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d7141e4928832986151548dc61723f